### PR TITLE
refactor: share database connection

### DIFF
--- a/src/commands/admin/cleancart.js
+++ b/src/commands/admin/cleancart.js
@@ -1,5 +1,4 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -17,15 +16,9 @@ module.exports = {
         await int.deferReply({ ephemeral: true });
         if (int.user.id !== '687004886922952755') return;
         const user = int.options.getUser('user');
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        try {
-            await localFunctions.delCart(user.id,collection);
-        } catch (e) {
-            console.log(e);
-        } finally {
-            mongoClient.close();
-        }
+        const collection = client.db.collection('OzenCollection');
 
+        await localFunctions.delCart(user.id, collection);
         await int.editReply(`Cart cleared for user ${user.tag}`);
     },
 }

--- a/src/commands/admin/give.js
+++ b/src/commands/admin/give.js
@@ -1,5 +1,4 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions')
 
 module.exports = {
@@ -22,6 +21,7 @@ module.exports = {
     async execute(int, client) {
         if (int.user.id !== '687004886922952755') return;
         await int.deferReply({ ephemeral: true });
+
         // Check if the command has the required arguments/options
         const userId = int.options.getUser('user');
         const amount = int.options.getInteger('amount');
@@ -31,17 +31,14 @@ module.exports = {
           return;
         }
     
-        // Establish a connection to MongoDB
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-    
-        try {
-          const currentBalance = await localFunctions.getBalance(userId.id, collection); // Fetch user's balance from the database
-          const newBalance = currentBalance + amount;
-          await localFunctions.setBalance(userId.id, newBalance, collection);
-    
-          await int.editReply({ content: `Assigned ${amount} credits to user <@${userId.id}>.`, ephemeral: true });
-        } finally {
-          mongoClient.close();
-        }
+
+        // Get the MongoDB collection
+        const collection = client.db.collection("OzenCollection");
+        
+        // Fetch user's balance from the database
+        const currentBalance = await localFunctions.getBalance(userId.id, collection); 
+        const newBalance = currentBalance + amount;
+        await localFunctions.setBalance(userId.id, newBalance, collection);
+        await int.editReply({ content: `Assigned ${amount} credits to user <@${userId.id}>.`, ephemeral: true });
     }   
 }

--- a/src/commands/admin/globalboost.js
+++ b/src/commands/admin/globalboost.js
@@ -24,11 +24,11 @@ module.exports = {
         const boostDuration = parseFloat(int.options.getString('timer'));
 
         if (isNaN(multiplier) || isNaN(boostDuration)) {
-        int.reply({ content: 'Please provide valid numerical values for multiplier and timer.', ephemeral: true });
-        return;
+          int.reply({ content: 'Please provide valid numerical values for multiplier and timer.', ephemeral: true });
+          return;
         }
 
         localFunctions.applyGlobalBoost(multiplier, boostDuration);
-        int.reply({ content: `Global boost of ${multiplier}x for ${boostDuration} hours has been applied.`, ephemeral: true });
+        await int.reply({ content: `Global boost of ${multiplier}x for ${boostDuration} hours has been applied.`, ephemeral: true });
     }    
 }

--- a/src/commands/admin/presdel.js
+++ b/src/commands/admin/presdel.js
@@ -17,7 +17,7 @@ module.exports = {
                         break;
                     }
                 }
-            })
-        })
+            });
+        });
     }
 }

--- a/src/commands/collabs/collabs.js
+++ b/src/commands/collabs/collabs.js
@@ -744,7 +744,7 @@ module.exports = {
                 .setAuthor({ name: `Welcome to your perks dashboard ${int.user.tag}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' });
             
 
-            let userPerks = await localFunctions.getPerks(userId, userCollection);
+            let userPerks = await localFunctions.getPerks(userId, collection);
             let submittedPerks = await localFunctions.getUserPerksAllCollabs(collabCollection, userId);
             const component = new ActionRowBuilder().addComponents(
                 new ButtonBuilder()
@@ -2005,7 +2005,7 @@ module.exports = {
                             await localFunctions.editCollabParticipantPickOnUser(userId, collab.name, newPickFull, collection);
 
                             let contentString = "";
-                            const snipes = await localFunctions.getCollabSnipes(collab.name, colabCollection, currentPick.id);
+                            const snipes = await localFunctions.getCollabSnipes(collab.name, collabCollection, currentPick.id);
                             if (typeof snipes !== "undefined") {
                                 if (typeof snipes.find(p => p.pick === currentPick.id) !== "undefined") {
                                     contentString = "Snipers! ";

--- a/src/commands/collabs/premium.js
+++ b/src/commands/collabs/premium.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
 const { SelectMenuBuilder, ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 
@@ -20,270 +19,252 @@ module.exports = {
         const guildMember = guild.members.cache.get(userId);
         const username = int.user.tag;
 
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB("Special");
+        const collection = client.db.collection("OzenCollection");
+        const collectionSpecial = client.db.collection("Special");
+
         const premiumEmbed = new EmbedBuilder()
             .setFooter({ text: 'Endless Mirage | Premium Dashboard\n', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
             .setColor('#f26e6a')
 
         if (!guildMember.roles.cache.has('743505566617436301')) {
-            try {
-                let userPerks = await localFunctions.getPerks(userId, collection);
-                if (userPerks.length !== 0) {
-                    let useMenu = new SelectMenuBuilder()
-                        .setCustomId('use-perks')
-                        .setPlaceholder('Use your perks.')
+            let userPerks = await localFunctions.getPerks(userId, collection);
+            if (userPerks.length !== 0) {
+                let useMenu = new SelectMenuBuilder()
+                    .setCustomId('use-perks')
+                    .setPlaceholder('Use your perks.')
 
-                    premiumEmbed.setAuthor({ name: `Welcome to your perks dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' });
-                    premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n✅ Perks available to use!\`\`\`**`);
-                    for (const perk of userPerks) {
-                        premiumEmbed.addFields({
-                            name: " ",
-                            value: `\`\`🎫 ${perk.name}\`\`
-                                 [├](https://discord.com/channels/630281137998004224/767374005782052864) ${perk.description}\n └ Your current renewal price is ${perk.individualPrice}$.`
-                        });
-                        useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
-                    }
-                    const useComponents = new ActionRowBuilder().addComponents(useMenu);
-                    let buyComponents = new ActionRowBuilder().addComponents(
-                        new ButtonBuilder()
-                            .setCustomId('premium-info')
-                            .setLabel('✒️ About')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('shopping-cart')
-                            .setLabel('🛒 Cart')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('perks-buy')
-                            .setLabel('🔀 Perk Shop')
-                            .setStyle('Primary'),
-                    )
-                    premiumEmbed.addFields(
-                        {
-                            name: "‎",
-                            value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                        }
-                    )
-                    await int.editReply({
-                        content: '',
-                        embeds: [premiumEmbed],
-                        components: [useComponents, buyComponents],
+                premiumEmbed.setAuthor({ name: `Welcome to your perks dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' });
+                premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n✅ Perks available to use!\`\`\`**`);
+                for (const perk of userPerks) {
+                    premiumEmbed.addFields({
+                        name: " ",
+                        value: `\`\`🎫 ${perk.name}\`\`
+                             [├](https://discord.com/channels/630281137998004224/767374005782052864) ${perk.description}\n └ Your current renewal price is ${perk.individualPrice}$.`
                     });
-                } else {
-                    premiumEmbed.setDescription('**\`\`\`ml\n 🚀 Welcome to the premium section!\`\`\`**                                                                                                           **In this section, you can find information about the current premium tiers and their perks!**\n\n**• The perks are ACCUMULATIVE.** \n**• After one collab, most perks will need to be RENEWED.** \n**• If there is no renewal, there is a DECAY into former supporter.**\n**• You can also purchase SINGLE PERKS for single use in collabs.**\n**• Premium includes bump immunity.**')
-                    premiumEmbed.addFields(
-                        { name: " ", value: "**\`\`\`ml\n⚠️ Only the prominent perks are mentioned for each tier.\`\`\`**" },
-                        { name: " ", value: "\`\`🎫 Mirage I Premium | Price: 5$\`\`\n └ Exclusive profile picture version." },
-                        { name: " ", value: "\`\`🎫 Mirage II Premium | Price: 10$\`\`\n └ Animated Banner." },
-                        { name: " ", value: "\`\`🎫 Mirage III Premium | Price: 15$\`\`\n └ Animated Stream Overlay." },
-                        { name: " ", value: "\`\`🎫 Mirage IV Premium | Price: 20$\`\`\n └ Early collab delivery.\n" },
-                        { name: " ", value: "\`\`🎫 Mirage V Premium | Price: 40$\`\`\n └ Customized collab themed osu! skin." },
-                        { name: " ", value: "\`\`🎫 Mirage VI Premium | Price: 100$\`\`\n └ Collab early access." },
-                        { name: " ", value: "\`\`🎫 Mirage VII Premium | Price: 250$\`\`\n └ Host your own megacollab." },
-                        { name: " ", value: "**\`\`\`prolog\n💎 Find the full details about each tier in the list bellow.\`\`\`\n<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>**" },
-                    );
-
-                    const defaultComponents = new ActionRowBuilder().addComponents(
-                        new SelectMenuBuilder()
-                            .setCustomId('premium-tiers')
-                            .setPlaceholder('Check the detailed tiers.')
-                            .addOptions([
-                                { label: 'Mirage I', value: 'Mirage I', description: 'Cost: 5$' },
-                                { label: 'Mirage II', value: 'Mirage II', description: 'Cost: 10$' },
-                                { label: 'Mirage III', value: 'Mirage III', description: 'Cost: 15$' },
-                                { label: 'Mirage IV', value: 'Mirage IV', description: 'Cost: 20$' },
-                                { label: 'Mirage V', value: 'Mirage V', description: 'Cost: 40$' },
-                                { label: 'Mirage VI', value: 'Mirage VI', description: 'Cost: 100$' },
-                                { label: 'Mirage VII', value: 'Mirage VII', description: 'Cost: 250$' },
-                            ])
-                    )
-                    await int.editReply({
-                        content: '',
-                        embeds: [premiumEmbed],
-                        components: [defaultComponents],
-                    });
+                    useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
                 }
-            } finally {
-                mongoClient.close();
-                mongoClientSpecial.close();
+                const useComponents = new ActionRowBuilder().addComponents(useMenu);
+                let buyComponents = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('premium-info')
+                        .setLabel('✒️ About')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('shopping-cart')
+                        .setLabel('🛒 Cart')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('perks-buy')
+                        .setLabel('🔀 Perk Shop')
+                        .setStyle('Primary'),
+                )
+                premiumEmbed.addFields(
+                    {
+                        name: "‎",
+                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                    }
+                )
+                await int.editReply({
+                    content: '',
+                    embeds: [premiumEmbed],
+                    components: [useComponents, buyComponents],
+                });
+            } else {
+                premiumEmbed.setDescription('**\`\`\`ml\n 🚀 Welcome to the premium section!\`\`\`**                                                                                                           **In this section, you can find information about the current premium tiers and their perks!**\n\n**• The perks are ACCUMULATIVE.** \n**• After one collab, most perks will need to be RENEWED.** \n**• If there is no renewal, there is a DECAY into former supporter.**\n**• You can also purchase SINGLE PERKS for single use in collabs.**\n**• Premium includes bump immunity.**')
+                premiumEmbed.addFields(
+                    { name: " ", value: "**\`\`\`ml\n⚠️ Only the prominent perks are mentioned for each tier.\`\`\`**" },
+                    { name: " ", value: "\`\`🎫 Mirage I Premium | Price: 5$\`\`\n └ Exclusive profile picture version." },
+                    { name: " ", value: "\`\`🎫 Mirage II Premium | Price: 10$\`\`\n └ Animated Banner." },
+                    { name: " ", value: "\`\`🎫 Mirage III Premium | Price: 15$\`\`\n └ Animated Stream Overlay." },
+                    { name: " ", value: "\`\`🎫 Mirage IV Premium | Price: 20$\`\`\n └ Early collab delivery.\n" },
+                    { name: " ", value: "\`\`🎫 Mirage V Premium | Price: 40$\`\`\n └ Customized collab themed osu! skin." },
+                    { name: " ", value: "\`\`🎫 Mirage VI Premium | Price: 100$\`\`\n └ Collab early access." },
+                    { name: " ", value: "\`\`🎫 Mirage VII Premium | Price: 250$\`\`\n └ Host your own megacollab." },
+                    { name: " ", value: "**\`\`\`prolog\n💎 Find the full details about each tier in the list bellow.\`\`\`\n<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>**" },
+                );
+
+                const defaultComponents = new ActionRowBuilder().addComponents(
+                    new SelectMenuBuilder()
+                        .setCustomId('premium-tiers')
+                        .setPlaceholder('Check the detailed tiers.')
+                        .addOptions([
+                            { label: 'Mirage I', value: 'Mirage I', description: 'Cost: 5$' },
+                            { label: 'Mirage II', value: 'Mirage II', description: 'Cost: 10$' },
+                            { label: 'Mirage III', value: 'Mirage III', description: 'Cost: 15$' },
+                            { label: 'Mirage IV', value: 'Mirage IV', description: 'Cost: 20$' },
+                            { label: 'Mirage V', value: 'Mirage V', description: 'Cost: 40$' },
+                            { label: 'Mirage VI', value: 'Mirage VI', description: 'Cost: 100$' },
+                            { label: 'Mirage VII', value: 'Mirage VII', description: 'Cost: 250$' },
+                        ])
+                )
+                await int.editReply({
+                    content: '',
+                    embeds: [premiumEmbed],
+                    components: [defaultComponents],
+                });
             }
         } else {
-            try {
-                let userPerks = await localFunctions.getPerks(userId, collection);
-                let premiumData = await localFunctions.getPremiumData(collectionSpecial);
-                let mainComponents = [];
-                let userTier = await localFunctions.getUserTier(userId, collection);
-                let monthlySupportData = await localFunctions.getUserMontlyPremium(userId, collection);
+            let userPerks = await localFunctions.getPerks(userId, collection);
+            let premiumData = await localFunctions.getPremiumData(collectionSpecial);
+            let mainComponents = [];
+            let userTier = await localFunctions.getUserTier(userId, collection);
+            let monthlySupportData = await localFunctions.getUserMontlyPremium(userId, collection);
 
-                if (!userTier && guildMember.roles.cache.has('743505566617436301') && !guildMember.roles.cache.has('1150484454071091280')) {
-                    let premiumDetails = await localFunctions.assignPremium(userId, collection, guildMember);
-                    userTier = premiumDetails[0];
-                    userPerks = premiumDetails[1];
-                    tierDetails = premiumDetails[2];
-                    tierString = `**Current Tier: ${userTier.name}**`;
-                } else if (userTier) {
-                    tierString = `**Current Tier: ${userTier.name}**`;
-                    tierDetails = localConstants.premiumTiers.find(tier => tier.name === userTier.name);
+            if (!userTier && guildMember.roles.cache.has('743505566617436301') && !guildMember.roles.cache.has('1150484454071091280')) {
+                let premiumDetails = await localFunctions.assignPremium(userId, collection, guildMember);
+                userTier = premiumDetails[0];
+                userPerks = premiumDetails[1];
+                tierDetails = premiumDetails[2];
+                tierString = `**Current Tier: ${userTier.name}**`;
+            } else if (userTier) {
+                tierString = `**Current Tier: ${userTier.name}**`;
+                tierDetails = localConstants.premiumTiers.find(tier => tier.name === userTier.name);
+            }
+
+            if (tierDetails.generalRenewalPrice) {
+                tierString = `${tierString}\n*Renewal price for all perks: ${tierDetails.generalRenewalPrice}$*`;
+            }
+
+            let activeMonthlySupport = false;
+            if (monthlySupportData) {
+                if (monthlySupportData.status !== "innactive") {
+                    activeMonthlySupport = true;
                 }
+            }
 
-                if (tierDetails.generalRenewalPrice) {
-                    tierString = `${tierString}\n*Renewal price for all perks: ${tierDetails.generalRenewalPrice}$*`;
-                }
+            let subComponent;
+            if (activeMonthlySupport) {
+                subComponent = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('sub-manage')
+                        .setLabel('💵 Manage Monthly Subscription')
+                        .setStyle('Primary'),
+                )
+            } else {
+                subComponent = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('subscribe')
+                        .setLabel('💵 Subscribe')
+                        .setStyle('Primary'),
+                )
+            }
 
-                let activeMonthlySupport = false;
-                if (monthlySupportData) {
-                    if (monthlySupportData.status !== "innactive") {
-                        activeMonthlySupport = true;
-                    }
-                }
+            if (userPerks?.length || activeMonthlySupport) {
+                let useMenu = new SelectMenuBuilder()
+                    .setCustomId('use-perks')
+                    .setPlaceholder('Use your perks.')
 
-                let subComponent;
-                if (activeMonthlySupport) {
-                    subComponent = new ActionRowBuilder().addComponents(
-                        new ButtonBuilder()
-                            .setCustomId('sub-manage')
-                            .setLabel('💵 Manage Monthly Subscription')
-                            .setStyle('Primary'),
-                    )
-                } else {
-                    subComponent = new ActionRowBuilder().addComponents(
-                        new ButtonBuilder()
-                            .setCustomId('subscribe')
-                            .setLabel('💵 Subscribe')
-                            .setStyle('Primary'),
-                    )
-                }
-
-                if (userPerks?.length || activeMonthlySupport) {
-                    let useMenu = new SelectMenuBuilder()
-                        .setCustomId('use-perks')
-                        .setPlaceholder('Use your perks.')
-
-                    premiumEmbed.setAuthor({ name: `Welcome to your premium dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' });
-                    // to rewrite into a single for loop with switch case
-                    if (userPerks.some(perk => perk.singleUse === false)) {
-                        premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n🔮 Permanent perks\`\`\`**`)
-                        tierString = ' '
-                        for (const perk of userPerks) {
-                            if ((!perk.singleUse || userTier.name === 'Mirage VII' || userTier.name === 'Mirage X') && perk.name !== 'Host your own Megacollab' && perk.name !== 'Custom Endless Mirage Hoodie') {
-                                if (perk.singleUse) {
-                                    useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
-                                }
-                                premiumEmbed.addFields({
-                                    name: " ",
-                                    value: `\`\`✒️ ${perk.name}\`\`\n └ ${perk.description}`
-                                });
-                            }
-                        }
-                    }
-                    if (userPerks.some(perk => perk.singleUse === true)) {
-                        if (tierString !== ' ') {
-                            premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n✅ Perks available to use!\`\`\`**`)
-                        } else {
-                            premiumEmbed.addFields(
-                                {
-                                    name: " ",
-                                    value: "**\`\`\`ml\n✅ Perks available to use!\`\`\`**",
-                                },
-                            )
-                        }
-                        for (const perk of userPerks) {
-                            if (perk.singleUse && userTier.name !== 'Mirage VII' && userTier.name !== 'Mirage X') {
-                                if (perk.renewalPrice) {
-                                    renewalPrice = `\n └ Your current renewal price is ${perk.renewalPrice}$.`;
-                                } else {
-                                    renewalPrice = '';
-                                }
-                                premiumEmbed.addFields({
-                                    name: " ",
-                                    value: `\`\`🎫 ${perk.name}\`\`\n ├ ${perk.description}${renewalPrice}`
-                                });
-                                useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
-                            } else if (perk.name === 'Custom Endless Mirage Hoodie' || perk.name === 'Host your own Megacollab') {
-                                premiumEmbed.addFields({
-                                    name: " ",
-                                    value: `\`\`🎫 ${perk.name}\`\`
-                                     └ ${perk.description}`
-                                });
+                premiumEmbed.setAuthor({ name: `Welcome to your premium dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' });
+                // to rewrite into a single for loop with switch case
+                if (userPerks.some(perk => perk.singleUse === false)) {
+                    premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n🔮 Permanent perks\`\`\`**`)
+                    tierString = ' '
+                    for (const perk of userPerks) {
+                        if ((!perk.singleUse || userTier.name === 'Mirage VII' || userTier.name === 'Mirage X') && perk.name !== 'Host your own Megacollab' && perk.name !== 'Custom Endless Mirage Hoodie') {
+                            if (perk.singleUse) {
                                 useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
                             }
-                        }
-                    }
-
-                    mainComponents = new ActionRowBuilder().addComponents(
-                        new ButtonBuilder()
-                            .setCustomId('premium-info')
-                            .setLabel('✒️ About')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('shopping-cart')
-                            .setLabel('🛒 Cart')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('perks-buy')
-                            .setLabel('🔀 Shop')
-                            .setStyle('Primary'),
-                    )
-
-                    if (userTier.name !== "Mirage VII" || userTier.name !== "Mirage X") {
-                        mainComponents.addComponents(
-                            new ButtonBuilder()
-                                .setCustomId('upgrade-tier')
-                                .setLabel('⏏️ Upgrade')
-                                .setStyle('Primary'),
-                            new ButtonBuilder()
-                                .setCustomId('premium-renew')
-                                .setLabel('🔁 Renew')
-                                .setStyle('Primary'),
-                        );
-                    }
-
-                    if (activeMonthlySupport) {
-                        const currentTier = localFunctions.premiumToInteger(userTier.name);
-                        let nextTier = 0;
-                        let fullNextTier;
-                        if (currentTier !== 7 && currentTier !== 10) {
-                            nextTier = currentTier + 1;
-                            fullNextTier = localConstants.premiumTiers[nextTier - 1];
-                            const totalSubAmount = parseInt(monthlySupportData.total);
-                            const monthlySubAmount = parseInt(monthlySupportData.currentAmount);
-                            const nextTierAmount = fullNextTier.cost;
-                            const pendingAmount = nextTierAmount - totalSubAmount;
-                            const monthsPending = Math.ceil(pendingAmount/monthlySubAmount);
-                            premiumEmbed.addFields(
-                                {
-                                    name: " ",
-                                    value: `**\`\`\`ml\n✅ Active subscription status!\`\`\`**\n\`\`❤️ Current Monthly Amount\`\`\n └ ${monthlySubAmount}$\n\n\`\`❤️ Time Pending for the Next Tier\`\`\n └ ${monthsPending} Month(s)!\n\n\`\`❤️ Amount Pending for the Next Tier\`\`\n └ ${pendingAmount}$\n\n*Your current subscription includes automatic renewal for all perks and free access to deluxe collabs.*\n*For more info about your subscription, use the manage button bellow!*`,
-                                },
-                            )
-                        } else {
-                            premiumEmbed.addFields(
-                                {
-                                    name: " ",
-                                    value: "**\`\`\`ml\n✅ Active subscription status!\`\`\`**\n**You're currently at the peak tier! Thank you for your incredible support!**\n\n*Your current subscription includes automatic renewal for all perks and free access to deluxe collabs.*\n*For more info about your subscription, use the manage button bellow!*",
-                                }
-                            )
-                        }
-
-                    }
-
-                    try {
-                        if (useMenu.options[0].data) {
-                            const useComponents = new ActionRowBuilder().addComponents(useMenu);
-                            premiumEmbed.addFields(
-                                {
-                                    name: "‎",
-                                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                                }
-                            )
-                            await int.editReply({
-                                content: '',
-                                embeds: [premiumEmbed],
-                                components: [useComponents, mainComponents, subComponent],
+                            premiumEmbed.addFields({
+                                name: " ",
+                                value: `\`\`✒️ ${perk.name}\`\`\n └ ${perk.description}`
                             });
                         }
-                    } catch (error) {
+                    }
+                }
+                if (userPerks.some(perk => perk.singleUse === true)) {
+                    if (tierString !== ' ') {
+                        premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n✅ Perks available to use!\`\`\`**`)
+                    } else {
+                        premiumEmbed.addFields(
+                            {
+                                name: " ",
+                                value: "**\`\`\`ml\n✅ Perks available to use!\`\`\`**",
+                            },
+                        )
+                    }
+                    for (const perk of userPerks) {
+                        if (perk.singleUse && userTier.name !== 'Mirage VII' && userTier.name !== 'Mirage X') {
+                            if (perk.renewalPrice) {
+                                renewalPrice = `\n └ Your current renewal price is ${perk.renewalPrice}$.`;
+                            } else {
+                                renewalPrice = '';
+                            }
+                            premiumEmbed.addFields({
+                                name: " ",
+                                value: `\`\`🎫 ${perk.name}\`\`\n ├ ${perk.description}${renewalPrice}`
+                            });
+                            useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
+                        } else if (perk.name === 'Custom Endless Mirage Hoodie' || perk.name === 'Host your own Megacollab') {
+                            premiumEmbed.addFields({
+                                name: " ",
+                                value: `\`\`🎫 ${perk.name}\`\`
+                                 └ ${perk.description}`
+                            });
+                            useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
+                        }
+                    }
+                }
+
+                mainComponents = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('premium-info')
+                        .setLabel('✒️ About')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('shopping-cart')
+                        .setLabel('🛒 Cart')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('perks-buy')
+                        .setLabel('🔀 Shop')
+                        .setStyle('Primary'),
+                )
+
+                if (userTier.name !== "Mirage VII" || userTier.name !== "Mirage X") {
+                    mainComponents.addComponents(
+                        new ButtonBuilder()
+                            .setCustomId('upgrade-tier')
+                            .setLabel('⏏️ Upgrade')
+                            .setStyle('Primary'),
+                        new ButtonBuilder()
+                            .setCustomId('premium-renew')
+                            .setLabel('🔁 Renew')
+                            .setStyle('Primary'),
+                    );
+                }
+
+                if (activeMonthlySupport) {
+                    const currentTier = localFunctions.premiumToInteger(userTier.name);
+                    let nextTier = 0;
+                    let fullNextTier;
+                    if (currentTier !== 7 && currentTier !== 10) {
+                        nextTier = currentTier + 1;
+                        fullNextTier = localConstants.premiumTiers[nextTier - 1];
+                        const totalSubAmount = parseInt(monthlySupportData.total);
+                        const monthlySubAmount = parseInt(monthlySupportData.currentAmount);
+                        const nextTierAmount = fullNextTier.cost;
+                        const pendingAmount = nextTierAmount - totalSubAmount;
+                        const monthsPending = Math.ceil(pendingAmount/monthlySubAmount);
+                        premiumEmbed.addFields(
+                            {
+                                name: " ",
+                                value: `**\`\`\`ml\n✅ Active subscription status!\`\`\`**\n\`\`❤️ Current Monthly Amount\`\`\n └ ${monthlySubAmount}$\n\n\`\`❤️ Time Pending for the Next Tier\`\`\n └ ${monthsPending} Month(s)!\n\n\`\`❤️ Amount Pending for the Next Tier\`\`\n └ ${pendingAmount}$\n\n*Your current subscription includes automatic renewal for all perks and free access to deluxe collabs.*\n*For more info about your subscription, use the manage button bellow!*`,
+                            },
+                        )
+                    } else {
+                        premiumEmbed.addFields(
+                            {
+                                name: " ",
+                                value: "**\`\`\`ml\n✅ Active subscription status!\`\`\`**\n**You're currently at the peak tier! Thank you for your incredible support!**\n\n*Your current subscription includes automatic renewal for all perks and free access to deluxe collabs.*\n*For more info about your subscription, use the manage button bellow!*",
+                            }
+                        )
+                    }
+
+                }
+
+                try {
+                    if (useMenu.options[0].data) {
+                        const useComponents = new ActionRowBuilder().addComponents(useMenu);
                         premiumEmbed.addFields(
                             {
                                 name: "‎",
@@ -293,39 +274,10 @@ module.exports = {
                         await int.editReply({
                             content: '',
                             embeds: [premiumEmbed],
-                            components: [mainComponents, subComponent],
+                            components: [useComponents, mainComponents, subComponent],
                         });
                     }
-
-                } else {
-
-                    decayString = `\n └ Your tier will decay <t:${premiumData.date}:R>.`;
-
-                    premiumEmbed.setAuthor({ name: `Welcome to your premium dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' })
-                    premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n⚠️ No perks available to claim!\`\`\`**`)
-                    premiumEmbed.addFields({ name: " ", value: `\`\`🎫 Notice\`\`\n ├ It\'s recommended to renew any of your perks.${decayString}` })
-                    mainComponents = new ActionRowBuilder().addComponents(
-                        new ButtonBuilder()
-                            .setCustomId('premium-info')
-                            .setLabel('✒️ About')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('shopping-cart')
-                            .setLabel('🛒 Cart')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('perks-buy')
-                            .setLabel('🔀 Shop')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('premium-renew')
-                            .setLabel('🔁 Renew')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('upgrade-tier')
-                            .setLabel('⏏️ Upgrade')
-                            .setStyle('Primary'),
-                    )
+                } catch (error) {
                     premiumEmbed.addFields(
                         {
                             name: "‎",
@@ -338,9 +290,46 @@ module.exports = {
                         components: [mainComponents, subComponent],
                     });
                 }
-            } finally {
-                mongoClient.close();
-                mongoClientSpecial.close();
+
+            } else {
+                decayString = `\n └ Your tier will decay <t:${premiumData.date}:R>.`;
+
+                premiumEmbed.setAuthor({ name: `Welcome to your premium dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' })
+                premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n⚠️ No perks available to claim!\`\`\`**`)
+                premiumEmbed.addFields({ name: " ", value: `\`\`🎫 Notice\`\`\n ├ It\'s recommended to renew any of your perks.${decayString}` })
+                mainComponents = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('premium-info')
+                        .setLabel('✒️ About')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('shopping-cart')
+                        .setLabel('🛒 Cart')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('perks-buy')
+                        .setLabel('🔀 Shop')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('premium-renew')
+                        .setLabel('🔁 Renew')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('upgrade-tier')
+                        .setLabel('⏏️ Upgrade')
+                        .setStyle('Primary'),
+                )
+                premiumEmbed.addFields(
+                    {
+                        name: "‎",
+                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                    }
+                )
+                await int.editReply({
+                    content: '',
+                    embeds: [premiumEmbed],
+                    components: [mainComponents, subComponent],
+                });
             }
         }
     }

--- a/src/commands/collabs/premiumcheck.js
+++ b/src/commands/collabs/premiumcheck.js
@@ -1,6 +1,5 @@
 const { SlashCommandBuilder, EmbedBuilder, PermissionFlagsBits } = require('discord.js');
 const { SelectMenuBuilder, ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 
@@ -31,247 +30,229 @@ module.exports = {
         const member = await guild.members.fetch(userId);
         const tiers = localConstants.premiumTiers;
 
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB("Special");
+        const collection = client.db.collection("OzenCollection");
+        const collectionSpecial = client.db.collection("Special");
+
         const premiumEmbed = new EmbedBuilder()
-                    .setFooter({ text: 'Endless Mirage | Premium Dashboard\n' , iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                    .setColor('#f26e6a')
+            .setFooter({ text: 'Endless Mirage | Premium Dashboard\n' , iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a');
 
         if (!member.roles.cache.has('743505566617436301')) {
-            try {
-                let userPerks = await localFunctions.getPerks(userId, collection);
-                if (userPerks.length !== 0) {
-                    let useMenu = new SelectMenuBuilder()
-                        .setCustomId('use-perks')
-                        .setPlaceholder('Use your perks.')
+            let userPerks = await localFunctions.getPerks(userId, collection);
+            if (userPerks.length !== 0) {
+                let useMenu = new SelectMenuBuilder()
+                    .setCustomId('use-perks')
+                    .setPlaceholder('Use your perks.')
 
-                    premiumEmbed.setAuthor({ name: `Welcome to your perks dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' });
-                    premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n✅ Perks available to use!\`\`\`**`);
-                    for (const perk of userPerks) {
-                        premiumEmbed.addFields({
-                            name: " ",
-                            value: `\`\`🎫 ${perk.name}\`\`
-                                 [├](https://discord.com/channels/630281137998004224/767374005782052864) ${perk.description}\n └ Your current renewal price is ${perk.individualPrice}$.`
-                        });
-                        useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
-                    }
-                    const useComponents = new ActionRowBuilder().addComponents(useMenu);
-                    let buyComponents = new ActionRowBuilder().addComponents(
-                        new ButtonBuilder()
-                            .setCustomId('premium-info')
-                            .setLabel('✒️ About')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('shopping-cart')
-                            .setLabel('🛒 Cart')
-                            .setStyle('Primary'),     
-                        new ButtonBuilder()
-                            .setCustomId('perks-buy')
-                            .setLabel('🔀 Perk Shop')
-                            .setStyle('Primary'),
-                    )
-                    premiumEmbed.addFields(
-                        {
-                            name: "‎",
-                            value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                        }
-                    )
-                    await int.editReply({
-                        content: '',
-                        embeds: [premiumEmbed],
-                        components: [useComponents, buyComponents],
+                premiumEmbed.setAuthor({ name: `Welcome to your perks dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' });
+                premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n✅ Perks available to use!\`\`\`**`);
+                for (const perk of userPerks) {
+                    premiumEmbed.addFields({
+                        name: " ",
+                        value: `\`\`🎫 ${perk.name}\`\`
+                             [├](https://discord.com/channels/630281137998004224/767374005782052864) ${perk.description}\n └ Your current renewal price is ${perk.individualPrice}$.`
                     });
-                } else {
-                    premiumEmbed.setDescription('**\`\`\`ml\n 🚀 Welcome to the premium section!\`\`\`**                                                                                                           **In this section, you can find information about the current premium tiers and their perks!**\n\n**• The perks are ACCUMULATIVE.** \n**• After one collab, most perks will need to be RENEWED.** \n**• If there is no renewal, there is a DECAY into former supporter.**\n**• You can also purchase SINGLE PERKS for single use in collabs.**\n**• Premium includes bump immunity.**')
-                    premiumEmbed.addFields(
-                        { name: " ", value: "**\`\`\`ml\n⚠️ Only the prominent perks are mentioned for each tier.\`\`\`**" }, 
-                        { name: " ", value: "\`\`🎫 Mirage I Premium | Price: 5$\`\`\n └ Exclusive profile picture version." },
-                        { name: " ", value: "\`\`🎫 Mirage II Premium | Price: 10$\`\`\n └ Animated Banner." },
-                        { name: " ", value: "\`\`🎫 Mirage III Premium | Price: 15$\`\`\n └ Animated Stream Overlay." },
-                        { name: " ", value: "\`\`🎫 Mirage IV Premium | Price: 20$\`\`\n └ Early collab delivery.\n" },
-                        { name: " ", value: "\`\`🎫 Mirage V Premium | Price: 40$\`\`\n └ Customized collab themed osu! skin." },
-                        { name: " ", value: "\`\`🎫 Mirage VI Premium | Price: 100$\`\`\n └ Collab early access." },
-                        { name: " ", value: "\`\`🎫 Mirage VII Premium | Price: 250$\`\`\n └ Host your own megacollab." },
-                        { name: " ", value: "**\`\`\`prolog\n💎 Find the full details about each tier in the list bellow.\`\`\`\n<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>**" },  
-                    );
-
-                    const defaultComponents = new ActionRowBuilder().addComponents(
-                        new SelectMenuBuilder()
-                            .setCustomId('premium-tiers')
-                            .setPlaceholder('Check the detailed tiers.')
-                            .addOptions([
-                                { label: 'Mirage I', value: 'Mirage I', description: 'Cost: 5$' },
-                                { label: 'Mirage II', value: 'Mirage II', description: 'Cost: 10$' },
-                                { label: 'Mirage III', value: 'Mirage III', description: 'Cost: 15$' },
-                                { label: 'Mirage IV', value: 'Mirage IV', description: 'Cost: 20$' },
-                                { label: 'Mirage V', value: 'Mirage V', description: 'Cost: 40$' },
-                                { label: 'Mirage VI', value: 'Mirage VI', description: 'Cost: 100$' },
-                                { label: 'Mirage VII', value: 'Mirage VII', description: 'Cost: 250$' },
-                            ])
-                    )                         
-                    await int.editReply({
-                        content: '',
-                        embeds: [premiumEmbed],
-                        components: [defaultComponents],
-                    });
+                    useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
                 }
-            } finally {
-                mongoClient.close();
-                mongoClientSpecial.close();
+                const useComponents = new ActionRowBuilder().addComponents(useMenu);
+                let buyComponents = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('premium-info')
+                        .setLabel('✒️ About')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('shopping-cart')
+                        .setLabel('🛒 Cart')
+                        .setStyle('Primary'),     
+                    new ButtonBuilder()
+                        .setCustomId('perks-buy')
+                        .setLabel('🔀 Perk Shop')
+                        .setStyle('Primary'),
+                )
+                premiumEmbed.addFields(
+                    {
+                        name: "‎",
+                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                    }
+                )
+                await int.editReply({
+                    content: '',
+                    embeds: [premiumEmbed],
+                    components: [useComponents, buyComponents],
+                });
+            } else {
+                premiumEmbed.setDescription('**\`\`\`ml\n 🚀 Welcome to the premium section!\`\`\`**                                                                                                           **In this section, you can find information about the current premium tiers and their perks!**\n\n**• The perks are ACCUMULATIVE.** \n**• After one collab, most perks will need to be RENEWED.** \n**• If there is no renewal, there is a DECAY into former supporter.**\n**• You can also purchase SINGLE PERKS for single use in collabs.**\n**• Premium includes bump immunity.**')
+                premiumEmbed.addFields(
+                    { name: " ", value: "**\`\`\`ml\n⚠️ Only the prominent perks are mentioned for each tier.\`\`\`**" }, 
+                    { name: " ", value: "\`\`🎫 Mirage I Premium | Price: 5$\`\`\n └ Exclusive profile picture version." },
+                    { name: " ", value: "\`\`🎫 Mirage II Premium | Price: 10$\`\`\n └ Animated Banner." },
+                    { name: " ", value: "\`\`🎫 Mirage III Premium | Price: 15$\`\`\n └ Animated Stream Overlay." },
+                    { name: " ", value: "\`\`🎫 Mirage IV Premium | Price: 20$\`\`\n └ Early collab delivery.\n" },
+                    { name: " ", value: "\`\`🎫 Mirage V Premium | Price: 40$\`\`\n └ Customized collab themed osu! skin." },
+                    { name: " ", value: "\`\`🎫 Mirage VI Premium | Price: 100$\`\`\n └ Collab early access." },
+                    { name: " ", value: "\`\`🎫 Mirage VII Premium | Price: 250$\`\`\n └ Host your own megacollab." },
+                    { name: " ", value: "**\`\`\`prolog\n💎 Find the full details about each tier in the list bellow.\`\`\`\n<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>**" },  
+                );
+
+                const defaultComponents = new ActionRowBuilder().addComponents(
+                    new SelectMenuBuilder()
+                        .setCustomId('premium-tiers')
+                        .setPlaceholder('Check the detailed tiers.')
+                        .addOptions([
+                            { label: 'Mirage I', value: 'Mirage I', description: 'Cost: 5$' },
+                            { label: 'Mirage II', value: 'Mirage II', description: 'Cost: 10$' },
+                            { label: 'Mirage III', value: 'Mirage III', description: 'Cost: 15$' },
+                            { label: 'Mirage IV', value: 'Mirage IV', description: 'Cost: 20$' },
+                            { label: 'Mirage V', value: 'Mirage V', description: 'Cost: 40$' },
+                            { label: 'Mirage VI', value: 'Mirage VI', description: 'Cost: 100$' },
+                            { label: 'Mirage VII', value: 'Mirage VII', description: 'Cost: 250$' },
+                        ])
+                )                         
+                await int.editReply({
+                    content: '',
+                    embeds: [premiumEmbed],
+                    components: [defaultComponents],
+                });
             }
         } else {
-            try {
-                let userPerks = await localFunctions.getPerks(userId, collection);
-                let premiumData = await localFunctions.getPremiumData(collectionSpecial);
-                let mainComponents = [];
-                let userTier = await localFunctions.getUserTier(userId, collection);
-                if (!userTier && member.roles.cache.has('743505566617436301') && !member.roles.cache.has('1150484454071091280')) {
-                    console.log('Executing insertion of perks'); //this needs to be moved into functions
-                    for (const numeral of localConstants.romanNumerals) { //find the fucker and assign it to the database
-                        const roleToFind = `Mirage ${numeral}`;
-                        foundRole = member.roles.cache.find(role => role.name === roleToFind);
+            let userPerks = await localFunctions.getPerks(userId, collection);
+            let premiumData = await localFunctions.getPremiumData(collectionSpecial);
+            let mainComponents = [];
+            let userTier = await localFunctions.getUserTier(userId, collection);
+            if (!userTier && member.roles.cache.has('743505566617436301') && !member.roles.cache.has('1150484454071091280')) {
+                console.log('Executing insertion of perks'); //this needs to be moved into functions
+                for (const numeral of localConstants.romanNumerals) { //find the fucker and assign it to the database
+                    const roleToFind = `Mirage ${numeral}`;
+                    foundRole = member.roles.cache.find(role => role.name === roleToFind);
 
-                        if (foundRole) {
-                            let tierNumber = localFunctions.romanToInteger(numeral);
-                            const foundTier = {
-                                name: foundRole.name,
-                                id: foundRole.id
-                            };
-                            await localFunctions.setUserTier(userId, foundTier, collection);
-                            userTier = foundTier;
-                            tierString = `**Current Tier: ${foundTier.name}**`;
-                            tierDetails = localConstants.premiumTiers.find(tier => tier.name === foundRole.name);
-                            if (tierNumber > 3) { //for non renewable fuck, assign the non renewable fuckers
-                                for (const tier of tiers) {
-                                    for (const perk of tier.perks) {
-                                        if ((tierNumber === 7 || tierNumber === 10) && (perk.name !== 'Host your own Megacollab' || perk.name !== 'Custom Endless Mirage Hoodie')) { //Peak tiers have all the perks permanent to them
-                                            newPerks.push(perk);
-                                            console.log(`Perk ${perk.name} has been pushed.`)
-                                        } else if (!perk.singleUse) {
-                                            newPerks.push(perk);
-                                            console.log(`Perk ${perk.name} has been pushed.`)
-                                        }
-                                    }
-                                    if (tier.name === roleToFind) {
-                                        await localFunctions.setPerks(userId, newPerks, collection);
-                                        console.log("Perks uploaded.")
-                                        userPerks = newPerks;
-                                        break;
+                    if (foundRole) {
+                        let tierNumber = localFunctions.romanToInteger(numeral);
+                        const foundTier = {
+                            name: foundRole.name,
+                            id: foundRole.id
+                        };
+                        await localFunctions.setUserTier(userId, foundTier, collection);
+                        userTier = foundTier;
+                        tierString = `**Current Tier: ${foundTier.name}**`;
+                        tierDetails = localConstants.premiumTiers.find(tier => tier.name === foundRole.name);
+                        if (tierNumber > 3) { //for non renewable fuck, assign the non renewable fuckers
+                            for (const tier of tiers) {
+                                for (const perk of tier.perks) {
+                                    if ((tierNumber === 7 || tierNumber === 10) && (perk.name !== 'Host your own Megacollab' || perk.name !== 'Custom Endless Mirage Hoodie')) { //Peak tiers have all the perks permanent to them
+                                        newPerks.push(perk);
+                                        console.log(`Perk ${perk.name} has been pushed.`)
+                                    } else if (!perk.singleUse) {
+                                        newPerks.push(perk);
+                                        console.log(`Perk ${perk.name} has been pushed.`)
                                     }
                                 }
+                                if (tier.name === roleToFind) {
+                                    await localFunctions.setPerks(userId, newPerks, collection);
+                                    console.log("Perks uploaded.")
+                                    userPerks = newPerks;
+                                    break;
+                                }
                             }
-                            break;
                         }
+                        break;
                     }
-                } else if (userTier) {
-                    tierString = `**Current Tier: ${userTier.name}**`;
-                    tierDetails = localConstants.premiumTiers.find(tier => tier.name === userTier.name);
-                } 
-
-                if (tierDetails.generalRenewalPrice) {
-                    tierString = `${tierString}\n*Renewal price for all perks: ${tierDetails.generalRenewalPrice}$*`;
                 }
+            } else if (userTier) {
+                tierString = `**Current Tier: ${userTier.name}**`;
+                tierDetails = localConstants.premiumTiers.find(tier => tier.name === userTier.name);
+            } 
 
-                if (userPerks?.length) {
-                    let useMenu = new SelectMenuBuilder()
-                        .setCustomId('use-perks')
-                        .setPlaceholder('Use your perks.')
+            if (tierDetails.generalRenewalPrice) {
+                tierString = `${tierString}\n*Renewal price for all perks: ${tierDetails.generalRenewalPrice}$*`;
+            }
 
-                    premiumEmbed.setAuthor({ name: `Welcome to your premium dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' });
+            if (userPerks?.length) {
+                let useMenu = new SelectMenuBuilder()
+                    .setCustomId('use-perks')
+                    .setPlaceholder('Use your perks.')
 
-                    if (userPerks.some(perk => perk.singleUse === false)) {
-                        premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n🔮 Permanent perks\`\`\`**`)
-                        tierString = ' '
-                        for (const perk of userPerks) {
-                            if ((!perk.singleUse || userTier.name === 'Mirage VII' || userTier.name === 'Mirage X') && perk.name !== 'Host your own Megacollab' && perk.name !== 'Custom Endless Mirage Hoodie') {
-                                if (perk.singleUse) {
-                                    useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
-                                }
-                                premiumEmbed.addFields({
-                                    name: " ",
-                                    value: `\`\`✒️ ${perk.name}\`\`\n └ ${perk.description}`
-                                });
-                            }
-                        }
-                    }
-                    if (userPerks.some(perk => perk.singleUse === true)) {
-                        if (tierString !== ' ') {
-                            premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n✅ Perks available to use!\`\`\`**`)
-                        } else {
-                            premiumEmbed.addFields(
-                                {
-                                    name: " ",
-                                    value: "**\`\`\`ml\n✅ Perks available to use!\`\`\`**",
-                                },
-                            )
-                        }
-                        for (const perk of userPerks) {
-                            if (perk.singleUse && userTier.name !== 'Mirage VII' && userTier.name !== 'Mirage X') {
-                                if (perk.renewalPrice) {
-                                    renewalPrice = `\n └ Your current renewal price is ${perk.renewalPrice}$.`;
-                                } else {
-                                    renewalPrice = '';
-                                }
-                                premiumEmbed.addFields({
-                                    name: " ",
-                                    value: `\`\`🎫 ${perk.name}\`\`\n ├ ${perk.description}${renewalPrice}`
-                                });
-                                useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
-                            } else if (perk.name === 'Custom Endless Mirage Hoodie' || perk.name === 'Host your own Megacollab') {
-                                premiumEmbed.addFields({
-                                    name: " ",
-                                    value: `\`\`🎫 ${perk.name}\`\`
-                                     └ ${perk.description}`
-                                });
+                premiumEmbed.setAuthor({ name: `Welcome to your premium dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' });
+
+                if (userPerks.some(perk => perk.singleUse === false)) {
+                    premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n🔮 Permanent perks\`\`\`**`)
+                    tierString = ' '
+                    for (const perk of userPerks) {
+                        if ((!perk.singleUse || userTier.name === 'Mirage VII' || userTier.name === 'Mirage X') && perk.name !== 'Host your own Megacollab' && perk.name !== 'Custom Endless Mirage Hoodie') {
+                            if (perk.singleUse) {
                                 useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
                             }
-                        }
-                    }
-
-                    mainComponents = new ActionRowBuilder().addComponents(
-                        new ButtonBuilder()
-                            .setCustomId('premium-info')
-                            .setLabel('✒️ About')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('shopping-cart')
-                            .setLabel('🛒 Cart')
-                            .setStyle('Primary'),    
-                        new ButtonBuilder()
-                            .setCustomId('perks-buy')
-                            .setLabel('🔀 Shop')
-                            .setStyle('Primary'),    
-                    )
-
-                    if (userTier.name !== "Mirage VII" || userTier.name !== "Mirage X") {
-                        mainComponents.addComponents(
-                        new ButtonBuilder()
-                            .setCustomId('upgrade-tier')
-                            .setLabel('⏏️ Upgrade')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('premium-renew')
-                            .setLabel('🔁 Renew')
-                            .setStyle('Primary'),
-                        );
-                    }
-
-                    try {
-                        if (useMenu.options[0].data) {
-                            const useComponents = new ActionRowBuilder().addComponents(useMenu);
-                            premiumEmbed.addFields(
-                                {
-                                    name: "‎",
-                                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                                }
-                            )
-                            await int.editReply({
-                                content: '',
-                                embeds: [premiumEmbed],
-                                components: [useComponents, mainComponents],
+                            premiumEmbed.addFields({
+                                name: " ",
+                                value: `\`\`✒️ ${perk.name}\`\`\n └ ${perk.description}`
                             });
                         }
-                    } catch (error) {
+                    }
+                }
+                if (userPerks.some(perk => perk.singleUse === true)) {
+                    if (tierString !== ' ') {
+                        premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n✅ Perks available to use!\`\`\`**`)
+                    } else {
+                        premiumEmbed.addFields(
+                            {
+                                name: " ",
+                                value: "**\`\`\`ml\n✅ Perks available to use!\`\`\`**",
+                            },
+                        )
+                    }
+                    for (const perk of userPerks) {
+                        if (perk.singleUse && userTier.name !== 'Mirage VII' && userTier.name !== 'Mirage X') {
+                            if (perk.renewalPrice) {
+                                renewalPrice = `\n └ Your current renewal price is ${perk.renewalPrice}$.`;
+                            } else {
+                                renewalPrice = '';
+                            }
+                            premiumEmbed.addFields({
+                                name: " ",
+                                value: `\`\`🎫 ${perk.name}\`\`\n ├ ${perk.description}${renewalPrice}`
+                            });
+                            useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
+                        } else if (perk.name === 'Custom Endless Mirage Hoodie' || perk.name === 'Host your own Megacollab') {
+                            premiumEmbed.addFields({
+                                name: " ",
+                                value: `\`\`🎫 ${perk.name}\`\`
+                                 └ ${perk.description}`
+                            });
+                            useMenu.addOptions({ label: perk.name, value: perk.name, description: perk.description });
+                        }
+                    }
+                }
+
+                mainComponents = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('premium-info')
+                        .setLabel('✒️ About')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('shopping-cart')
+                        .setLabel('🛒 Cart')
+                        .setStyle('Primary'),    
+                    new ButtonBuilder()
+                        .setCustomId('perks-buy')
+                        .setLabel('🔀 Shop')
+                        .setStyle('Primary'),    
+                )
+
+                if (userTier.name !== "Mirage VII" || userTier.name !== "Mirage X") {
+                    mainComponents.addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('upgrade-tier')
+                        .setLabel('⏏️ Upgrade')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('premium-renew')
+                        .setLabel('🔁 Renew')
+                        .setStyle('Primary'),
+                    );
+                }
+
+                try {
+                    if (useMenu.options[0].data) {
+                        const useComponents = new ActionRowBuilder().addComponents(useMenu);
                         premiumEmbed.addFields(
                             {
                                 name: "‎",
@@ -281,39 +262,10 @@ module.exports = {
                         await int.editReply({
                             content: '',
                             embeds: [premiumEmbed],
-                            components: [mainComponents],
+                            components: [useComponents, mainComponents],
                         });
                     }
-
-                } else {
-
-                    decayString = `\n └ Your tier will decay <t:${premiumData.date}:R>.`;
-
-                    premiumEmbed.setAuthor({ name: `Welcome to your premium dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' })
-                    premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n⚠️ No perks available to claim!\`\`\`**`)
-                    premiumEmbed.addFields({ name: " ", value: `\`\`🎫 Notice\`\`\n ├ It\'s recommended to renew any of your perks.${decayString}` })
-                    mainComponents = new ActionRowBuilder().addComponents(
-                        new ButtonBuilder()
-                            .setCustomId('premium-info')
-                            .setLabel('✒️ About')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('shopping-cart')
-                            .setLabel('🛒 Cart')
-                            .setStyle('Primary'),   
-                        new ButtonBuilder()
-                            .setCustomId('perks-buy')
-                            .setLabel('🔀 Shop')
-                            .setStyle('Primary'),      
-                        new ButtonBuilder()
-                            .setCustomId('premium-renew')
-                            .setLabel('🔁 Renew')
-                            .setStyle('Primary'),
-                        new ButtonBuilder()
-                            .setCustomId('upgrade-tier')
-                            .setLabel('⏏️ Upgrade')
-                            .setStyle('Primary'),    
-                    )
+                } catch (error) {
                     premiumEmbed.addFields(
                         {
                             name: "‎",
@@ -325,10 +277,47 @@ module.exports = {
                         embeds: [premiumEmbed],
                         components: [mainComponents],
                     });
-                } 
-            } finally {
-                mongoClient.close();
-                mongoClientSpecial.close();
+                }
+
+            } else {
+                decayString = `\n └ Your tier will decay <t:${premiumData.date}:R>.`;
+
+                premiumEmbed.setAuthor({ name: `Welcome to your premium dashboard ${username}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' })
+                premiumEmbed.setDescription(`${tierString}\n                                                                                                        **\`\`\`ml\n⚠️ No perks available to claim!\`\`\`**`)
+                premiumEmbed.addFields({ name: " ", value: `\`\`🎫 Notice\`\`\n ├ It\'s recommended to renew any of your perks.${decayString}` })
+                mainComponents = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('premium-info')
+                        .setLabel('✒️ About')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('shopping-cart')
+                        .setLabel('🛒 Cart')
+                        .setStyle('Primary'),   
+                    new ButtonBuilder()
+                        .setCustomId('perks-buy')
+                        .setLabel('🔀 Shop')
+                        .setStyle('Primary'),      
+                    new ButtonBuilder()
+                        .setCustomId('premium-renew')
+                        .setLabel('🔁 Renew')
+                        .setStyle('Primary'),
+                    new ButtonBuilder()
+                        .setCustomId('upgrade-tier')
+                        .setLabel('⏏️ Upgrade')
+                        .setStyle('Primary'),    
+                )
+                premiumEmbed.addFields(
+                    {
+                        name: "‎",
+                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                    }
+                )
+                await int.editReply({
+                    content: '',
+                    embeds: [premiumEmbed],
+                    components: [mainComponents],
+                });
             }
         }    
     }

--- a/src/commands/collabs/removetier.js
+++ b/src/commands/collabs/removetier.js
@@ -1,5 +1,4 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -16,15 +15,15 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         if (int.user.id !== '687004886922952755') return;
+
         const user = int.options.getUser('user');
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
+
         try {
-            await localFunctions.delTier(user.id,collection);
+            await localFunctions.delTier(user.id, collection);
             console.log(`Tier removed for user ${user.tag}`)
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
         }
 
         await int.editReply(`Tier removed for user ${user.tag}`);

--- a/src/commands/collabs/setperks.js
+++ b/src/commands/collabs/setperks.js
@@ -1,5 +1,4 @@
 const { SlashCommandBuilder, PermissionFlagsBits } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions')
 
 module.exports = {
@@ -13,8 +12,8 @@ module.exports = {
                 .setDescription('Set status [on/off].')
                 .setRequired(true)
                 .addChoices(
-                { name: 'on', value: 'on' },
-                { name: 'off', value: 'off' },
+                    { name: 'on', value: 'on' },
+                    { name: 'off', value: 'off' },
                 )
         )
         .addIntegerOption(option => 
@@ -25,20 +24,22 @@ module.exports = {
         ),
     async execute(int, client) {
         if (int.user.id !== '687004886922952755') return;
+
         const status = int.options.getString('switch');
         const decayDate = int.options.getInteger('decaydate');
         let newStatus = 0;
-        const { collection, client: mongoClientSpecial } = await connectToMongoDB("Special");
+        const collection = client.db.collection("Special");
+
         if (status === "on") {
             newStatus = 1;
         }
+
         try {
             await localFunctions.setPerkUsage(newStatus, collection);
             await localFunctions.setPerkStartingDecayDate(decayDate, collection);
-            int.reply({ content: `New perk usage status: ${status}`, ephemeral: true });
+            await int.reply({ content: `New perk usage status: ${status}`, ephemeral: true });
         } catch (error) {
-            int.reply({ content: `Something went wrong: ${error}`, ephemeral: true });
-            mongoClientSpecial.close();
+            await int.reply({ content: `Something went wrong: ${error}`, ephemeral: true });
         }
     }    
 }

--- a/src/components/buttons/accept-trade.js
+++ b/src/components/buttons/accept-trade.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -11,9 +10,12 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB('Special');
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
+        
+        // Grab the MongoDB collections.
+        const collection = client.db.collection("Collabs");
+        const collectionSpecial = client.db.collection("Special");
+        const userCollection = client.db.collection("OzenCollection");
+
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         try {
@@ -141,10 +143,6 @@ module.exports = {
 
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
-            mongoClientSpecial.close();
         }
     }
 }

--- a/src/components/buttons/admin-collab.js
+++ b/src/components/buttons/admin-collab.js
@@ -1,6 +1,5 @@
 const { EmbedBuilder } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { buttonCache } = require('../selectMenus/select-collab');
@@ -15,7 +14,8 @@ module.exports = {
         const guild = client.guilds.cache.get(localConstants.guildId);
         const guildMember = guild.members.cache.get(int.user.id);
         if (!guildMember.roles.cache.has('630636502187114496')) return;
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("Collabs");
+        
         try {
             let collab = await localFunctions.getCollab(buttonCache.get(int.user.id).collab, collection)
             let components = [];
@@ -154,8 +154,6 @@ module.exports = {
         } catch (e) {
             console.log(e)
             await int.editReply('Something went wrong...')
-        } finally {
-            mongoClient.close();
         }
     },
     collabCache: collabCache

--- a/src/components/buttons/buy-no.js
+++ b/src/components/buttons/buy-no.js
@@ -8,7 +8,7 @@ module.exports = {
         const userConfirmation = userConfirmationCache.get(int.user.id);
         // User canceled the purchase
         if (userConfirmation) {
-          int.reply({ content: 'Purchase Cancelled.', ephemeral: true });
+          await int.reply({ content: 'Purchase Cancelled.', ephemeral: true });
         }
         // Remove the user's confirmation from the cache
         userConfirmationCache.delete(int.user.id);

--- a/src/components/buttons/buy-yes.js
+++ b/src/components/buttons/buy-yes.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
 const { userConfirmationCache } = require('../selectMenus/buy-item');
@@ -15,51 +14,47 @@ module.exports = {
         const purchasedItem = userConfirmation.item;
         const purchasedItemValue = parseInt(purchasedItem.value.replace(/[^\d]/g, ''));
 
-        // Establish a connection to MongoDB
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        // Grab the MongoDB collection.
+        const collection = client.db.collection("OzenCollection");
 
-        try {
-            // Check if the user has enough tokens
-            const currentBalance = await localFunctions.getBalance(userId, collection);
+        // Check if the user has enough tokens
+        const currentBalance = await localFunctions.getBalance(userId, collection);
 
-            // Retrieve the user's current inventory from the database
-            let userInventory = await localFunctions.getInventory(userId, collection) || [];
+        // Retrieve the user's current inventory from the database
+        let userInventory = await localFunctions.getInventory(userId, collection) || [];
 
-            // Check if userInventory is an array, if not, initialize it as an empty array
-            if (!Array.isArray(userInventory)) {
-                userInventory = [];
-            }
+        // Check if userInventory is an array, if not, initialize it as an empty array
+        if (!Array.isArray(userInventory)) {
+            userInventory = [];
+        }
 
-            if (!userInventory.some((item) => item.name === purchasedItem.name)) {
-                // Deduct the tokens
-                const newBalance = currentBalance - purchasedItemValue;
-                await localFunctions.setBalance(userId, newBalance, collection);
+        if (!userInventory.some((item) => item.name === purchasedItem.name)) {
+            // Deduct the tokens
+            const newBalance = currentBalance - purchasedItemValue;
+            await localFunctions.setBalance(userId, newBalance, collection);
 
-                // Add the purchased item to the user's inventory
-                userInventory.push(purchasedItem);
+            // Add the purchased item to the user's inventory
+            userInventory.push(purchasedItem);
 
-                // Save the updated inventory back to the database
-                await localFunctions.setInventory(userId, userInventory, collection);
+            // Save the updated inventory back to the database
+            await localFunctions.setInventory(userId, userInventory, collection);
 
-                int.reply({ content: `You have successfully purchased ${purchasedItem.name}! Make sure to check your inventory with the command \`\`/inventory\`\` to use your item.`, ephemeral: true });
+            int.reply({ content: `You have successfully purchased ${purchasedItem.name}! Make sure to check your inventory with the command \`\`/inventory\`\` to use your item.`, ephemeral: true });
 
-                const purchasesLogChannel = int.guild.channels.cache.get('1150891338166976553');
-                const purchasesLogEmbed = new EmbedBuilder()
-                    .setColor('#f26e6a')
-                    .setImage('https://puu.sh/JPffc/3c792e61c9.png')
-                    .setAuthor({ name: "✔️ A new purchase has been made.", iconURL: int.user.displayAvatarURL() })
-                    .setThumbnail('https://puu.sh/JP9Iw/a365159d0e.png')
-                    .setDescription(`**Item: ${purchasedItem.name}**\n**Purchased by <@${int.user.id}>**\n**Value: ${purchasedItemValue} ₥**\nDate: <t:${Math.floor(new Date(Date.now()) / 1000)}:F>.`)
-                    .setTimestamp();
-                purchasesLogChannel.send({ content: '', embeds: [purchasesLogEmbed] });
+            const purchasesLogChannel = int.guild.channels.cache.get('1150891338166976553');
+            const purchasesLogEmbed = new EmbedBuilder()
+                .setColor('#f26e6a')
+                .setImage('https://puu.sh/JPffc/3c792e61c9.png')
+                .setAuthor({ name: "✔️ A new purchase has been made.", iconURL: int.user.displayAvatarURL() })
+                .setThumbnail('https://puu.sh/JP9Iw/a365159d0e.png')
+                .setDescription(`**Item: ${purchasedItem.name}**\n**Purchased by <@${int.user.id}>**\n**Value: ${purchasedItemValue} ₥**\nDate: <t:${Math.floor(new Date(Date.now()) / 1000)}:F>.`)
+                .setTimestamp();
+            purchasesLogChannel.send({ content: '', embeds: [purchasesLogEmbed] });
 
-                // Remove the user's confirmation from the cache
-                userConfirmationCache.delete(int.user.id);
-            } else {
-                int.reply({ content: `You already have ${purchasedItem.name}.`, ephemeral: true });
-            }
-        } finally {
-            mongoClient.close();
+            // Remove the user's confirmation from the cache
+            userConfirmationCache.delete(int.user.id);
+        } else {
+            await int.reply({ content: `You already have ${purchasedItem.name}.`, ephemeral: true });
         }
     }
 }

--- a/src/components/buttons/checkout.js
+++ b/src/components/buttons/checkout.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -13,56 +12,53 @@ module.exports = {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
         let totalCost = 0;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
         const checkoutEmbed = new EmbedBuilder()
             .setFooter({ text: 'Endless Mirage', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
             .setColor('#f26e6a')
-            .setTimestamp();    
-        try {
-            let checkoutItems = await localFunctions.getCart(userId, collection);
-            if (checkoutItems.length) {
-                checkoutEmbed.setDescription("**\`\`\`prolog\n💎 Your Payment link is ready!\`\`\`**\n*At the moment, we only support PayPal and Ko-fi Payments.*")   
-                for (let item of checkoutItems) {
+            .setTimestamp();
+            
+        let checkoutItems = await localFunctions.getCart(userId, collection);
+        if (checkoutItems.length) {
+            checkoutEmbed.setDescription("**\`\`\`prolog\n💎 Your Payment link is ready!\`\`\`**\n*At the moment, we only support PayPal and Ko-fi Payments.*")   
+            for (let item of checkoutItems) {
 
-                    totalCost = totalCost + item.price;
-                }
-                await localFunctions.setCurrentPendingPayment(userId, totalCost, collection);
-                checkoutEmbed.addFields(
-                    {
-                        name: `**\`\`💳 Amount to pay: ${totalCost}$\`\`**`,
-                        value: "Once the Payment is **completed**, press the **Verify Payment** Button for verification and asignation of your items.",
-                    },
-                ) 
-                let checkoutComponents = new ActionRowBuilder().addComponents(
-                    new ButtonBuilder()
-                        .setLabel('💳 PayPal')
-                        .setURL(`${localConstants.paypal}${totalCost}`)
-                        .setStyle('Link'),   
-                    new ButtonBuilder()
-                        .setLabel('💳 Ko-Fi')
-                        .setURL(`${localConstants.kofi}${totalCost}`)
-                        .setStyle('Link'),      
-                    new ButtonBuilder()
-                        .setCustomId('verify-payment')
-                        .setLabel('✅ Verify Payment')
-                        .setStyle('Success'),
-                )
-                checkoutEmbed.addFields(
-                    {
-                        name: "‎",
-                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                    }
-                )
-                await int.editReply({
-                    content: '',
-                    embeds: [checkoutEmbed],
-                    components: [checkoutComponents],
-                });
-            } else {
-                await int.editReply('Something went wrong...');
+                totalCost = totalCost + item.price;
             }
-        } finally {
-            mongoClient.close();
-        } 
+            await localFunctions.setCurrentPendingPayment(userId, totalCost, collection);
+            checkoutEmbed.addFields(
+                {
+                    name: `**\`\`💳 Amount to pay: ${totalCost}$\`\`**`,
+                    value: "Once the Payment is **completed**, press the **Verify Payment** Button for verification and asignation of your items.",
+                },
+            ) 
+            let checkoutComponents = new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setLabel('💳 PayPal')
+                    .setURL(`${localConstants.paypal}${totalCost}`)
+                    .setStyle('Link'),   
+                new ButtonBuilder()
+                    .setLabel('💳 Ko-Fi')
+                    .setURL(`${localConstants.kofi}${totalCost}`)
+                    .setStyle('Link'),      
+                new ButtonBuilder()
+                    .setCustomId('verify-payment')
+                    .setLabel('✅ Verify Payment')
+                    .setStyle('Success'),
+            )
+            checkoutEmbed.addFields(
+                {
+                    name: "‎",
+                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                }
+            )
+            await int.editReply({
+                content: '',
+                embeds: [checkoutEmbed],
+                components: [checkoutComponents],
+            });
+        } else {
+            await int.editReply('Something went wrong...');
+        }
     }
 }

--- a/src/components/buttons/claim-pick.js
+++ b/src/components/buttons/claim-pick.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
@@ -14,9 +13,12 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB('Special');
+
+        // MongoDB collections.
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+        const collectionSpecial = client.db.collection("Special");
+
         const guild = client.guilds.cache.get(localConstants.guildId);
         const guildMember = guild.members.cache.get(userId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
@@ -292,10 +294,6 @@ module.exports = {
 
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
-            mongoClientSpecial.close();
         }
     }
 }

--- a/src/components/buttons/collab-bump.js
+++ b/src/components/buttons/collab-bump.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 
@@ -8,54 +7,54 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
+        
+        // MongoDB collections.
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+
         const userId = int.user.id;
         const guild = client.guilds.cache.get(localConstants.guildId);
+        const allCollabs = await localFunctions.getCollabs(collection);
+        const userCollabs = await localFunctions.getUserCollabs(userId, userCollection);
+        const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && (c.status === "open" || c.status === "early access" || c.status === "on design"));
+        
         try {
-            const allCollabs = await localFunctions.getCollabs(collection);
-            const userCollabs = await localFunctions.getUserCollabs(userId, userCollection);
-            const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && (c.status === "open" || c.status === "early access" || c.status === "on design"));
-            try {
-                if (typeof userCollabs.find(uc => uc.collabName === openMegacollab.name) === "undefined") {
-                    return int.editReply('You\'re not participating on this collab! To join use the ``/collabs quick join`` command.');
-                }
-            } catch {
+            if (typeof userCollabs.find(uc => uc.collabName === openMegacollab.name) === "undefined") {
                 return int.editReply('You\'re not participating on this collab! To join use the ``/collabs quick join`` command.');
             }
-            const collab = openMegacollab;
-            const participation = collab.participants.find(u => u.discordId === userId);
-            if (participation.bump_imune) return int.editReply('You\'re immune to bumps! How awesome.');
-            const bumps = collab.bumps;
-            if (typeof bumps === "undefined") return int.editReply('The bumps for the current megacollab have not started yet!');
-            const currentBumpIndex = bumps.length - 1;
-            const currentDate = Math.floor(Date.now() / 1000);
-            if (typeof bumps[currentBumpIndex].users.find(u => u.discordId === userId) !== "undefined") return int.editReply('You have already bumped!');
-            let userBumps = {};
-            for (const bump of bumps) {
-                if (typeof bump.users.find(u => u.discordId === userId) !== "undefined") {
-                    userBumps.push(bump);
-                }
-            }
-            if (currentDate - bumps[currentBumpIndex].startingDate > bumps[currentBumpIndex].days * 24 * 60 * 60) return int.editReply(`The time window to bump has passed! Please try again on the next one. You have completed ${userBumps.length} of ${currentBumpIndex + 1} bumps.`);
-            const bumpEntry = {
-                discordId: userId,
-                date: currentDate,
-            }
-            if (participation.referral) {
-                const referralCode = participation.referral;
-                const inviterUser = await localFunctions.getUserByReferral(referralCode, userCollection);
-                const logChannel = guild.channels.cache.get(localConstants.logChannelID);
-                let currentBalance = inviterUser.balance;
-                currentBalance = currentBalance + 2000;
-                await localFunctions.setBalance(inviterUser._id, currentBalance, userCollection);
-                logChannel.send({ content: `<@${inviterUser._id}> The user ${int.user.tag} has bumped their pick and you've received **2000** tokens!`})
-            }
-            await localFunctions.addCollabBumpUser(collab.name, collection, bumps[currentBumpIndex], bumpEntry);
-            await int.editReply('You have bumped your participation succesfully');
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
+        } catch {
+            return int.editReply('You\'re not participating on this collab! To join use the ``/collabs quick join`` command.');
         }
+
+        const collab = openMegacollab;
+        const participation = collab.participants.find(u => u.discordId === userId);
+        if (participation.bump_imune) return int.editReply('You\'re immune to bumps! How awesome.');
+        const bumps = collab.bumps;
+        if (typeof bumps === "undefined") return int.editReply('The bumps for the current megacollab have not started yet!');
+        const currentBumpIndex = bumps.length - 1;
+        const currentDate = Math.floor(Date.now() / 1000);
+        if (typeof bumps[currentBumpIndex].users.find(u => u.discordId === userId) !== "undefined") return int.editReply('You have already bumped!');
+        let userBumps = {};
+        for (const bump of bumps) {
+            if (typeof bump.users.find(u => u.discordId === userId) !== "undefined") {
+                userBumps.push(bump);
+            }
+        }
+        if (currentDate - bumps[currentBumpIndex].startingDate > bumps[currentBumpIndex].days * 24 * 60 * 60) return int.editReply(`The time window to bump has passed! Please try again on the next one. You have completed ${userBumps.length} of ${currentBumpIndex + 1} bumps.`);
+        const bumpEntry = {
+            discordId: userId,
+            date: currentDate,
+        }
+        if (participation.referral) {
+            const referralCode = participation.referral;
+            const inviterUser = await localFunctions.getUserByReferral(referralCode, userCollection);
+            const logChannel = guild.channels.cache.get(localConstants.logChannelID);
+            let currentBalance = inviterUser.balance;
+            currentBalance = currentBalance + 2000;
+            await localFunctions.setBalance(inviterUser._id, currentBalance, userCollection);
+            logChannel.send({ content: `<@${inviterUser._id}> The user ${int.user.tag} has bumped their pick and you've received **2000** tokens!`})
+        }
+        await localFunctions.addCollabBumpUser(collab.name, collection, bumps[currentBumpIndex], bumpEntry);
+        await int.editReply('You have bumped your participation succesfully');
     }
 }

--- a/src/components/buttons/deliver-collab.js
+++ b/src/components/buttons/deliver-collab.js
@@ -1,7 +1,7 @@
 const { TextInputStyle } = require('discord.js');
 const { ActionRowBuilder, ModalBuilder, TextInputBuilder } = require('@discordjs/builders');
 const { collabCache } = require('./admin-collab');
-const { adminCache }= require('../../commands/collabs/collabs');
+const { adminCache } = require('../../commands/collabs/collabs');
 
 module.exports = {
     data: {

--- a/src/components/buttons/edit-collab.js
+++ b/src/components/buttons/edit-collab.js
@@ -1,5 +1,5 @@
 const { collabCache } = require('./admin-collab');
-const { adminCache }= require('../../commands/collabs/collabs');
+const { adminCache } = require('../../commands/collabs/collabs');
 const editCache = new Map();
 
 module.exports = {

--- a/src/components/buttons/edit-fields-report.js
+++ b/src/components/buttons/edit-fields-report.js
@@ -1,64 +1,58 @@
 const { TextInputStyle } = require('discord.js');
 const { ActionRowBuilder, ModalBuilder, TextInputBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { reportCache } = require('../buttons/report-accept');
-
 
 module.exports = {
     data: {
         name: 'edit-fields-report'
     },
     async execute(int, client) {
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        try {
-            const collab = await localFunctions.getCollab(reportCache.get(int.user.id).report.collab, collection);
+        const collection = client.db.collection("Collabs");
+        const collab = await localFunctions.getCollab(reportCache.get(int.user.id).report.collab, collection);
 
-            const modal = new ModalBuilder()
-                .setCustomId("edit-fields-report")
-                .setTitle('Edit the fields of an user in the collab.');
+        const modal = new ModalBuilder()
+            .setCustomId("edit-fields-report")
+            .setTitle('Edit the fields of an user in the collab.');
 
-            const av_text = new TextInputBuilder()
-                .setCustomId('av_text')
-                .setLabel('Type the text for the avatar.')
-                .setMinLength(2)
-                .setMaxLength(collab.fieldRestrictions.av)
-                .setStyle(TextInputStyle.Short)
-                .setRequired(false);
+        const av_text = new TextInputBuilder()
+            .setCustomId('av_text')
+            .setLabel('Type the text for the avatar.')
+            .setMinLength(2)
+            .setMaxLength(collab.fieldRestrictions.av)
+            .setStyle(TextInputStyle.Short)
+            .setRequired(false);
 
-            const ca_text = new TextInputBuilder()
-                .setCustomId('ca_text')
-                .setLabel('Type the text for the card.')
-                .setMinLength(2)
-                .setMaxLength(collab.fieldRestrictions.ca)
-                .setStyle(TextInputStyle.Short)
-                .setRequired(false);
+        const ca_text = new TextInputBuilder()
+            .setCustomId('ca_text')
+            .setLabel('Type the text for the card.')
+            .setMinLength(2)
+            .setMaxLength(collab.fieldRestrictions.ca)
+            .setStyle(TextInputStyle.Short)
+            .setRequired(false);
 
-            const ca_quote = new TextInputBuilder()
-                .setCustomId('ca_quote')
-                .setLabel('Type a quote for the card.')
-                .setMinLength(2)
-                .setMaxLength(collab.fieldRestrictions.ca_quote)
-                .setStyle(TextInputStyle.Short)
-                .setRequired(false);
+        const ca_quote = new TextInputBuilder()
+            .setCustomId('ca_quote')
+            .setLabel('Type a quote for the card.')
+            .setMinLength(2)
+            .setMaxLength(collab.fieldRestrictions.ca_quote)
+            .setStyle(TextInputStyle.Short)
+            .setRequired(false);
 
-            const imgURL = new TextInputBuilder()
-                .setCustomId('img')
-                .setLabel('Replace the image for this user.')
-                .setStyle(TextInputStyle.Short)
-                .setRequired(false);
+        const imgURL = new TextInputBuilder()
+            .setCustomId('img')
+            .setLabel('Replace the image for this user.')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(false);
 
-            const reason = new TextInputBuilder()
-                .setCustomId('reason')
-                .setLabel('Type a reason')
-                .setStyle(TextInputStyle.Short)
-                .setRequired(true);
+        const reason = new TextInputBuilder()
+            .setCustomId('reason')
+            .setLabel('Type a reason')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true);
 
-            modal.addComponents(new ActionRowBuilder().addComponents(av_text), new ActionRowBuilder().addComponents(ca_text), new ActionRowBuilder().addComponents(ca_quote), new ActionRowBuilder().addComponents(imgURL), new ActionRowBuilder().addComponents(reason));
+        modal.addComponents(new ActionRowBuilder().addComponents(av_text), new ActionRowBuilder().addComponents(ca_text), new ActionRowBuilder().addComponents(ca_quote), new ActionRowBuilder().addComponents(imgURL), new ActionRowBuilder().addComponents(reason));
 
-            await int.showModal(modal);
-        } finally {
-            mongoClient.close();
-        }
-    },
-}
+        await int.showModal(modal);
+    }
+};

--- a/src/components/buttons/empty-cart.js
+++ b/src/components/buttons/empty-cart.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -8,12 +7,9 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");   
-        try {
-            await localFunctions.delCart(userId,collection);
-            await int.editReply("Your cart is now empty.");
-        } finally {
-            mongoClient.close();
-        } 
+        const collection = client.db.collection("OzenCollection");
+        
+        await localFunctions.delCart(userId, collection);
+        await int.editReply("Your cart is now empty.");
     }
 }

--- a/src/components/buttons/export-collab.js
+++ b/src/components/buttons/export-collab.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { AttachmentBuilder } = require('discord.js');
 const { collabCache } = require('./admin-collab');
@@ -11,38 +10,37 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply();
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        try {
-            const collab = await localFunctions.getCollab(collabCache.get(int.user.id).collab.name, collection);
-            if (collab.host !== int.user.id) {
-                int.editReply('You are not allowed to do this.');
-                return;
-            }
-
-            let initializedMap;
-            if (collabCache.size > 0) {
-                if (typeof collabCache.get(int.user.id) !== "undefined") {
-                    initializedMap = collabCache;
-                }
-            }
-            if (adminCache.size > 0) {
-                if (typeof adminCache.get(int.user.id) !== "undefined") {
-                    initializedMap = adminCache;
-                }
-            }
-
-            const collabParticipants = await localFunctions.getCollabParticipants(initializedMap.get(int.user.id).collab.name, collection);
-            const headers = Object.keys(collabParticipants[0]);
-            const csvStringifier = createObjectCsvStringifier({
-                header: headers.map(header => ({ id: header, title: header }))
-            });
-            const csvData = csvStringifier.getHeaderString() + '\n' + csvStringifier.stringifyRecords(collabParticipants);
-            const attachment = new AttachmentBuilder(Buffer.from(csvData), {
-                name: `${collab.name} Data.csv`
-            });
-            await int.editReply({ files: [attachment] });
-        } finally {
-            mongoClient.close();
+        const collection = client.db.collection("Collabs");
+        const collab = await localFunctions.getCollab(collabCache.get(int.user.id).collab.name, collection);
+        
+        if (collab.host !== int.user.id) {
+            int.editReply('You are not allowed to do this.');
+            return;
         }
+
+        let initializedMap;
+        if (collabCache.size > 0) {
+            if (typeof collabCache.get(int.user.id) !== "undefined") {
+                initializedMap = collabCache;
+            }
+        }
+
+        if (adminCache.size > 0) {
+            if (typeof adminCache.get(int.user.id) !== "undefined") {
+                initializedMap = adminCache;
+            }
+        }
+
+        const collabParticipants = await localFunctions.getCollabParticipants(initializedMap.get(int.user.id).collab.name, collection);
+        const headers = Object.keys(collabParticipants[0]);
+        const csvStringifier = createObjectCsvStringifier({
+            header: headers.map(header => ({ id: header, title: header }))
+        });
+        const csvData = csvStringifier.getHeaderString() + '\n' + csvStringifier.stringifyRecords(collabParticipants);
+        const attachment = new AttachmentBuilder(Buffer.from(csvData), {
+            name: `${collab.name} Data.csv`
+        });
+
+        await int.editReply({ files: [attachment] });
     }
 }

--- a/src/components/buttons/leave-collab.js
+++ b/src/components/buttons/leave-collab.js
@@ -1,6 +1,5 @@
 const { TextInputStyle } = require('discord.js');
 const { ActionRowBuilder, ModalBuilder, TextInputBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { profileButtonCache } = require('./profile-pick');
 const { profileMenuCache } = require('../selectMenus/manage-collab');
@@ -23,32 +22,29 @@ module.exports = {
                 initializedMap = profileButtonCache;
             }
         }
+
         const collab = initializedMap.get(userId).collab;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        try {
-            const userCollabData = await localFunctions.getUserCollabs(userId, collection);
-            const currentCollab = userCollabData.find(e => e.collabName === collab.name);
-            const currentPick = currentCollab.collabPick.name;
-            const modal = new ModalBuilder()
-                .setCustomId("leave-collab")
-                .setTitle(`${collab.name}`);
+        const collection = client.db.collection("OzenCollection");
+        const userCollabData = await localFunctions.getUserCollabs(userId, collection);
+        const currentCollab = userCollabData.find(e => e.collabName === collab.name);
+        const currentPick = currentCollab.collabPick.name;
+        const modal = new ModalBuilder()
+            .setCustomId("leave-collab")
+            .setTitle(`${collab.name}`);
 
-            const pick = new TextInputBuilder()
-                .setCustomId('pick')
-                .setLabel("Type the name of your pick to leave.")
-                .setPlaceholder(`${currentPick}`)
-                .setStyle(TextInputStyle.Short)
+        const pick = new TextInputBuilder()
+            .setCustomId('pick')
+            .setLabel("Type the name of your pick to leave.")
+            .setPlaceholder(`${currentPick}`)
+            .setStyle(TextInputStyle.Short)
 
-            modal.addComponents(new ActionRowBuilder().addComponents(pick));
+        modal.addComponents(new ActionRowBuilder().addComponents(pick));
 
-            leaveCache.set(int.user.id, {
-                collab: currentCollab,
-              })
+        leaveCache.set(int.user.id, {
+            collab: currentCollab,
+        });
 
-            await int.showModal(modal);
-        } finally {
-            mongoClient.close();
-        }
+        await int.showModal(modal);
     },
     leaveCache: leaveCache
 };

--- a/src/components/buttons/link-osu.js
+++ b/src/components/buttons/link-osu.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { TextInputStyle } = require('discord.js');
 const { ActionRowBuilder, ModalBuilder, TextInputBuilder } = require('@discordjs/builders');
@@ -10,36 +9,33 @@ module.exports = {
     },
     async execute(int, client) {
         const userId = int.user.id;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        main: try {
-            let userOsuData = await localFunctions.getOsuData(userId, collection);
-            if (userOsuData) {
-                int.reply({content: 'You already have your osu! account linked!', ephemeral: true});
-                break main;
-            }
-            const modal = new ModalBuilder()
-                .setCustomId("fetch-profile")
-                .setTitle('Link your osu! account');
+        const collection = client.db.collection("OzenCollection");
+        let userOsuData = await localFunctions.getOsuData(userId, collection);
 
-            const name = new TextInputBuilder()
-                .setCustomId('name')
-                .setLabel('Type your osu! name')
-                .setStyle(TextInputStyle.Short)
-                .setRequired(true);
-            
-            const mode = new TextInputBuilder()
-                .setCustomId('mode')
-                .setLabel('Type your main gamemode')
-                .setPlaceholder('osu | fruits | mania | taiko')
-                .setStyle(TextInputStyle.Short)
-                .setRequired(true);    
-
-            modal.addComponents(new ActionRowBuilder().addComponents(name), new ActionRowBuilder().addComponents(mode));
-
-            await int.showModal(modal);
-
-        } finally {
-            mongoClient.close();
+        if (userOsuData) {
+            await int.reply({content: 'You already have your osu! account linked!', ephemeral: true });
+            return;
         }
-    },
-}
+
+        const modal = new ModalBuilder()
+            .setCustomId("fetch-profile")
+            .setTitle('Link your osu! account');
+
+        const name = new TextInputBuilder()
+            .setCustomId('name')
+            .setLabel('Type your osu! name')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true);
+        
+        const mode = new TextInputBuilder()
+            .setCustomId('mode')
+            .setLabel('Type your main gamemode')
+            .setPlaceholder('osu | fruits | mania | taiko')
+            .setStyle(TextInputStyle.Short)
+            .setRequired(true);    
+
+        modal.addComponents(new ActionRowBuilder().addComponents(name), new ActionRowBuilder().addComponents(mode));
+
+        await int.showModal(modal);
+    }
+};

--- a/src/components/buttons/perk-edit.js
+++ b/src/components/buttons/perk-edit.js
@@ -4,7 +4,6 @@ const { managePerkCache } = require('../selectMenus/manage-perks');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const perkCache = new Map();
-const { connectToMongoDB } = require('../../mongo');
 
 module.exports = {
     data: {
@@ -12,9 +11,10 @@ module.exports = {
     },
     async execute(int, client) {
         const collabName = managePerkCache.get(int.user.id).collabName;
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collabCollection = client.db.collection("Collabs");
         const perkName = managePerkCache.get(int.user.id).perkName;
         const fullPerk = localConstants.premiumPerks.find(p => p.name === perkName);
+
         try {
             const fullCollab = await localFunctions.getCollab(collabName, collabCollection);
             const fieldRestrictions = fullCollab.fieldRestrictions.premium_perks;
@@ -52,9 +52,7 @@ module.exports = {
             });
         } catch {
             await int.reply({ content: 'Try this interaction again... this took more than 3 seconds for some reason', ephemeral: true });
-        } finally {
-            mongoClientCollabs.close();
         }
     },
     perkCache: perkCache
-}
+};

--- a/src/components/buttons/perks-buy.js
+++ b/src/components/buttons/perks-buy.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -11,7 +10,7 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
         const userId = int.user.id;
         let userTier = 0;
         let arrayOfObjects = [];
@@ -20,117 +19,113 @@ module.exports = {
         let buyMenu = new SelectMenuBuilder()
             .setCustomId('add-content-to-cart')
             .setPlaceholder('Add content to your shopping cart.')  
-            .setMinValues(1)
+            .setMinValues(1);
 
         let buyEmbed = new EmbedBuilder()  
             .setColor('#f26e6a')
             .setAuthor({ name: `Welcome to the perk shop ${int.user.tag}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' })
-            .setFooter({ text: 'Endless Mirage | Premium Dashboard', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setFooter({ text: 'Endless Mirage | Premium Dashboard', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' });
 
-        try {
-            let userCart = await localFunctions.getCart(userId, collection);
-            let userPerks = await localFunctions.getPerks(userId, collection);
-            let dbTier = await localFunctions.getTier(userId, collection);
-            let fullTier = [];
-            let userPerksNR = [];
-            let allPossiblePerks = [];
-            let renewalString = '';
-            let purchaseablePerks = [];
-            let i = false;
-            if (typeof dbTier !== "undefined") {
-                if (dbTier.length !== 0) {
-                    userTier = localFunctions.premiumToInteger(dbTier.name);
-                    fullTier = localConstants.premiumTiers.find((e) => e.name === dbTier.name);
-                    renewalString = `*Renewal Price for all perks: ${fullTier.generalRenewalPrice ? fullTier.generalRenewalPrice : 'You are on the peak tier! Your renewal price is 0'}$`
-                    allPossiblePerks = await localFunctions.getFullPerksOfTier(userTier);
-                    userPerksNR = userPerks.filter((e) => e.renewalPrice !== null);
-                    if (typeof allPossiblePerks.find((e) => userPerks.find((p) => p.name === e.name)) === "undefined" && typeof dbTier !== "undefined") {
-                        buyMenu.addOptions({ label: fullTier.name, value: fullTier.name, description: `Renewal cost: ${fullTier.generalRenewalPrice}$` });
-                        arrayOfObjects.push({ name: fullTier.name, type: "Renewal", price: fullTier.generalRenewalPrice, tier: fullTier.id, class: 'Tier' });
-                    } 
-                } else {
-                    userTier = 0
-                    dbTier = {name: 'None!'}
-                    renewalString = "Renewal of all perks is not possible with the current premium status."
-                }
+        let userCart = await localFunctions.getCart(userId, collection);
+        let userPerks = await localFunctions.getPerks(userId, collection);
+        let dbTier = await localFunctions.getTier(userId, collection);
+        let fullTier = [];
+        let userPerksNR = [];
+        let allPossiblePerks = [];
+        let renewalString = '';
+        let purchaseablePerks = [];
+        let i = false;
+        if (typeof dbTier !== "undefined") {
+            if (dbTier.length !== 0) {
+                userTier = localFunctions.premiumToInteger(dbTier.name);
+                fullTier = localConstants.premiumTiers.find((e) => e.name === dbTier.name);
+                renewalString = `*Renewal Price for all perks: ${fullTier.generalRenewalPrice ? fullTier.generalRenewalPrice : 'You are on the peak tier! Your renewal price is 0'}$`
+                allPossiblePerks = await localFunctions.getFullPerksOfTier(userTier);
+                userPerksNR = userPerks.filter((e) => e.renewalPrice !== null);
+                if (typeof allPossiblePerks.find((e) => userPerks.find((p) => p.name === e.name)) === "undefined" && typeof dbTier !== "undefined") {
+                    buyMenu.addOptions({ label: fullTier.name, value: fullTier.name, description: `Renewal cost: ${fullTier.generalRenewalPrice}$` });
+                    arrayOfObjects.push({ name: fullTier.name, type: "Renewal", price: fullTier.generalRenewalPrice, tier: fullTier.id, class: 'Tier' });
+                } 
             } else {
                 userTier = 0
                 dbTier = {name: 'None!'}
                 renewalString = "Renewal of all perks is not possible with the current premium status."
             }
-            if (dbTier.name !== "None!" && (userTier !== 7 && userTier !== 10) && !localFunctions.compareArrays(allPossiblePerks, userPerksNR)) {
-                renewalString = renewalString.concat("*\n                                                                                                        **\`\`\`prolog\n💵 Renewable perks\`\`\`**\n")
-                buyEmbed.setDescription(`**Current Tier: ${dbTier.name}**\n${renewalString}`);
-                i = true;
-            } else if ((userTier === 7 || userTier === 10) && localFunctions.compareArrays(userPerksNR,allPossiblePerks)) {
-                renewalString = renewalString.concat("*\n                                                                                                        **\`\`\`ml\n🥂 Nice to see you here! If you're interested on another hoodie or hosting another megacollab, DM xegc!\`\`\`**")
-                buyEmbed.setDescription(`**Current Tier: ${dbTier.name}**\n${renewalString}`);
-                buyMenu.addOptions({ label: 'The love from the server owner', value: 'secret', description: "uwu (I had to add something lol discord gets angry if I don't)" });
-                i = true;
-            }
-            localConstants.premiumTiers.forEach((tier) => {  
-                tier.perks.forEach((perk) => {
-                    if (!(userCart.find(p => p.name === perk.name) || userPerks.find(pp => pp.name === perk.name)) && perk.renewalPrice && perk.individualPrice) {
-                        if (perk.renewalPrice && (userTier >= tier.id)) {
-                            buyEmbed.addFields(
-                                {
-                                    name: " ",
-                                    value: `\`\`✒️ ${perk.avname}\`\`\n **└ Renewal:** ${perk.renewalPrice}$`,
-                                    inline: true,
-                                }
-                            )
-                            buyMenu.addOptions({ label: perk.name, value: perk.name, description: `Renewal cost: ${perk.renewalPrice}$` });
-                            arrayOfObjects.push({ name: perk.name, type: "Renewal", price: perk.renewalPrice, tier: tier.id, class: 'Perk' });
-                        } else if (perk.individualPrice && ((tier.id > userTier) || ((userTier === 7 || userTier === 10) && (perk.avname === 'Endless Mirage Hoodie' || perk.avname === 'Host a Megacollab')))) {
-                            let neededData = {avname: perk.avname, name: perk.name, individualPrice: perk.individualPrice, id: tier.id}
-                            purchaseablePerks.push(neededData);
-                        }
+        } else {
+            userTier = 0
+            dbTier = {name: 'None!'}
+            renewalString = "Renewal of all perks is not possible with the current premium status."
+        }
+        if (dbTier.name !== "None!" && (userTier !== 7 && userTier !== 10) && !localFunctions.compareArrays(allPossiblePerks, userPerksNR)) {
+            renewalString = renewalString.concat("*\n                                                                                                        **\`\`\`prolog\n💵 Renewable perks\`\`\`**\n")
+            buyEmbed.setDescription(`**Current Tier: ${dbTier.name}**\n${renewalString}`);
+            i = true;
+        } else if ((userTier === 7 || userTier === 10) && localFunctions.compareArrays(userPerksNR,allPossiblePerks)) {
+            renewalString = renewalString.concat("*\n                                                                                                        **\`\`\`ml\n🥂 Nice to see you here! If you're interested on another hoodie or hosting another megacollab, DM xegc!\`\`\`**")
+            buyEmbed.setDescription(`**Current Tier: ${dbTier.name}**\n${renewalString}`);
+            buyMenu.addOptions({ label: 'The love from the server owner', value: 'secret', description: "uwu (I had to add something lol discord gets angry if I don't)" });
+            i = true;
+        }
+        localConstants.premiumTiers.forEach((tier) => {  
+            tier.perks.forEach((perk) => {
+                if (!(userCart.find(p => p.name === perk.name) || userPerks.find(pp => pp.name === perk.name)) && perk.renewalPrice && perk.individualPrice) {
+                    if (perk.renewalPrice && (userTier >= tier.id)) {
+                        buyEmbed.addFields(
+                            {
+                                name: " ",
+                                value: `\`\`✒️ ${perk.avname}\`\`\n **└ Renewal:** ${perk.renewalPrice}$`,
+                                inline: true,
+                            }
+                        )
+                        buyMenu.addOptions({ label: perk.name, value: perk.name, description: `Renewal cost: ${perk.renewalPrice}$` });
+                        arrayOfObjects.push({ name: perk.name, type: "Renewal", price: perk.renewalPrice, tier: tier.id, class: 'Perk' });
+                    } else if (perk.individualPrice && ((tier.id > userTier) || ((userTier === 7 || userTier === 10) && (perk.avname === 'Endless Mirage Hoodie' || perk.avname === 'Host a Megacollab')))) {
+                        let neededData = {avname: perk.avname, name: perk.name, individualPrice: perk.individualPrice, id: tier.id}
+                        purchaseablePerks.push(neededData);
                     }
-                });
-            }); 
-            if (purchaseablePerks.length !== 0) {
-                if (i) {
-                    buyEmbed.addFields(
-                        {
-                            name: " ",
-                            value: "**\`\`\`prolog\n💵 Purchaseable perks\`\`\`**\n",
-                        }
-                    )
-                } else {
-                    renewalString = renewalString.concat("*\n                                                                                                        **\`\`\`prolog\n💵 Purchaseable perks\`\`\`**\n")
-                    buyEmbed.setDescription(`**Current Tier: ${dbTier.name}**\n${renewalString}`);
                 }
-                for (let perk of purchaseablePerks) {
-                    buyEmbed.addFields(
-                        {
-                            name: " ",
-                            value: `\`\`✒️ ${perk.avname}\`\`\n **└ Cost:** ${perk.individualPrice}$`,
-                            inline: true,
-                        }
-                    )
-                    buyMenu.addOptions({ label: perk.name, value: perk.name, description: `Purchase cost: ${perk.individualPrice}$` });
-                    arrayOfObjects.push({ name: perk.name, type: "Perk", price: perk.individualPrice, tier: perk.id });
-                }
+            });
+        }); 
+        if (purchaseablePerks.length !== 0) {
+            if (i) {
+                buyEmbed.addFields(
+                    {
+                        name: " ",
+                        value: "**\`\`\`prolog\n💵 Purchaseable perks\`\`\`**\n",
+                    }
+                )
+            } else {
+                renewalString = renewalString.concat("*\n                                                                                                        **\`\`\`prolog\n💵 Purchaseable perks\`\`\`**\n")
+                buyEmbed.setDescription(`**Current Tier: ${dbTier.name}**\n${renewalString}`);
             }
-            buyMenu.setMaxValues(buyMenu.options.length);
-            buyComponents = new ActionRowBuilder().addComponents(buyMenu);
-            perkCache.set(int.user.id, {
-                choices: arrayOfObjects,
-            });
-            buyEmbed.addFields(
-                {
-                    name: "‎",
-                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                }
-            )
-            await int.editReply({
-                content: '',
-                embeds: [buyEmbed],
-                components: [buyComponents],
-            });
-        } finally {
-            mongoClient.close();
-        }      
+            for (let perk of purchaseablePerks) {
+                buyEmbed.addFields(
+                    {
+                        name: " ",
+                        value: `\`\`✒️ ${perk.avname}\`\`\n **└ Cost:** ${perk.individualPrice}$`,
+                        inline: true,
+                    }
+                )
+                buyMenu.addOptions({ label: perk.name, value: perk.name, description: `Purchase cost: ${perk.individualPrice}$` });
+                arrayOfObjects.push({ name: perk.name, type: "Perk", price: perk.individualPrice, tier: perk.id });
+            }
+        }
+        buyMenu.setMaxValues(buyMenu.options.length);
+        buyComponents = new ActionRowBuilder().addComponents(buyMenu);
+        perkCache.set(int.user.id, {
+            choices: arrayOfObjects,
+        });
+        buyEmbed.addFields(
+            {
+                name: "‎",
+                value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+            }
+        )
+        await int.editReply({
+            content: '',
+            embeds: [buyEmbed],
+            components: [buyComponents],
+        });    
     },
     perkCache: perkCache
 }

--- a/src/components/buttons/pool-collab.js
+++ b/src/components/buttons/pool-collab.js
@@ -1,5 +1,5 @@
 const { collabCache } = require('../buttons/admin-collab');
-const { adminCache }= require('../../commands/collabs/collabs');
+const { adminCache } = require('../../commands/collabs/collabs');
 const poolCache = new Map();
 
 module.exports = {

--- a/src/components/buttons/premium-buy.js
+++ b/src/components/buttons/premium-buy.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -18,7 +17,7 @@ module.exports = {
         if (int.message.channelId === '767374005782052864') {
             messageId = int.message.id;
         }
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
         const userId = int.user.id;
         const guildMember = await guild.members.fetch(userId)
         var arrayOfObjects = [];
@@ -138,8 +137,7 @@ module.exports = {
             console.log(e);
         } finally {
             selectionTier.delete(int.user.id);
-            mongoClient.close();
-        } 
+        }
     },
     premiumBuyCache: premiumBuyCache
 }

--- a/src/components/buttons/premium-renew.js
+++ b/src/components/buttons/premium-renew.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -10,7 +9,7 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
         const userId = int.user.id;
 
         mainProcess: try {
@@ -89,7 +88,6 @@ module.exports = {
 
         } catch (e) {
             console.log(e);
-            mongoClient.close();
-        }    
+        }
     }
 }

--- a/src/components/buttons/profile-collab.js
+++ b/src/components/buttons/profile-collab.js
@@ -1,7 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder, SelectMenuBuilder } = require('@discordjs/builders');
 const { tools } = require('osu-api-extended');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 
@@ -14,215 +13,214 @@ module.exports = {
         const guild = client.guilds.cache.get(localConstants.guildId);
         const guildMember = guild.members.cache.get(userId);
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
-        try {
-            const userOsu = await localFunctions.getOsuData(userId, collection);
-            const lastUpdate = await localFunctions.getUserLastUpdate(userId, collection);
-            const currentDate = Math.floor(Date.now() / 1000);
-            if (!userOsu) {
-                const components = new ActionRowBuilder().addComponents(
-                    new ButtonBuilder()
-                        .setCustomId('link-osu')
-                        .setLabel('🔗 Link your osu! Account')
-                        .setStyle('Success'),
-                )
-                await int.editReply({
-                    content: 'It seems like you haven\'t linked your osu! account with Miira. To proceed please link it using the button bellow.',
-                    components: [components]
-                });
-                return;
-            }
-            const collabData = await localFunctions.getUserCollabs(userId, collection);
-            const collabs = await localFunctions.getCollabs(collabCollection);
-            let buttons;
 
-            let tier = 0;
-            let prestigeLevel = 0;
-            let prestige = guildMember.roles.cache.find(role => localConstants.prestigeRolesIDs.includes(role.id));
-            if (typeof prestige !== "undefined") {
-                prestige = prestige.name
+        const collection = client.db.collection("OzenCollection");
+        const collabCollection = client.db.collection("Collabs");
+        const userOsu = await localFunctions.getOsuData(userId, collection);
+        const lastUpdate = await localFunctions.getUserLastUpdate(userId, collection);
+        const currentDate = Math.floor(Date.now() / 1000);
+        
+        if (!userOsu) {
+            const components = new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setCustomId('link-osu')
+                    .setLabel('🔗 Link your osu! Account')
+                    .setStyle('Success'),
+            )
+            await int.editReply({
+                content: 'It seems like you haven\'t linked your osu! account with Miira. To proceed please link it using the button bellow.',
+                components: [components]
+            });
 
-                prestigeLevel = parseInt(prestige.replace('Prestige ', ''));
-            }
-            const userTier = await localFunctions.getUserTier(userId, collection);
-            if (userTier) {
-                tier = localFunctions.premiumToInteger(userTier.name);
-            } else if (guildMember.roles.cache.has('743505566617436301')) {
-                let premiumDetails = await localFunctions.assignPremium(userId, collection, guildMember);
-                tier = localFunctions.premiumToInteger(premiumDetails[0].name);
-            }
-
-            const osuEmbed = new EmbedBuilder()
-                .setColor('#f26e6a')
-                .setThumbnail(userOsu.avatar_url)
-                .addFields(
-                    {
-                        name: "‎",
-                        value: `┌ Username: **${userOsu.username}**\n├ Country: **${tools.country(userOsu.country_code)}**\n├ Rank: **${userOsu.statistics.global_rank ? userOsu.statistics.global_rank : "Unranked"}**\n├ Peak Rank: **${userOsu.rank_highest.rank}**\n└ Level: **${userOsu.statistics.level.current}**`,
-                        inline: true
-                    },
-                    {
-                        name: "‎",
-                        value: `┌ Performance: **${userOsu.statistics.pp}pp**\n├ Join date: **<t:${new Date(userOsu.join_date).getTime() / 1000}:R>**\n├ Prestige Level: **${prestigeLevel}**\n├ Premium Tier: **${tier}**\n└ Playtime: **${Math.floor(userOsu.statistics.play_time / 3600)}h**`,
-                        inline: true
-                    },
-                    {
-                        name: "‎",
-                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:06:1195440954895765647><:08:1195440957735325707><:09:1195440958850998302><:11:1195441090677968936><:12:1195440961275306025><:14:1195441092947103847><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                    },
-                )
-            if (typeof userOsu.skillRanks !== 'undefined') {
-                osuEmbed.addFields(
-                    {
-                        name: "‎",
-                        value: `┌ ACC: **${userOsu.skillRanks[0].rank}** | Score: **${userOsu.skillRanks[0].int}**\n├ REA: **${userOsu.skillRanks[1].rank}** | Score: **${userOsu.skillRanks[1].int}**\n├ AIM: **${userOsu.skillRanks[2].rank}** | Score: **${userOsu.skillRanks[2].int}**\n├ SPD: **${userOsu.skillRanks[3].rank}** | Score: **${userOsu.skillRanks[3].int}**\n├ STA: **${userOsu.skillRanks[4].rank}** | Score: **${userOsu.skillRanks[4].int}**\n└ PRE: **${userOsu.skillRanks[5].rank}** | Score: **${userOsu.skillRanks[5].int}**`,
-                        inline: true
-                    },
-                    {
-                        name: "‎",
-                        value: `┌ Top 1 Mod: **${userOsu.modsData.top4Mods[0].mod}** | Usage: **${Math.round(userOsu.modsData.top4Mods[0].percentage)}%**\n├ Top 2 Mod: **${userOsu.modsData.top4Mods[1].mod}** | Usage: **${Math.round(userOsu.modsData.top4Mods[1].percentage)}%**\n├ Top 3 Mod: **${userOsu.modsData.top4Mods[2].mod}** | Usage: **${Math.round(userOsu.modsData.top4Mods[2].percentage)}%**\n├ Top 4 Mod: **${userOsu.modsData.top4Mods[3].mod}** | Usage: **${Math.round(userOsu.modsData.top4Mods[3].percentage) ? Math.round(userOsu.modsData.top4Mods[3].percentage) : userOsu.modsData.top4Mods[3].percentage}%**\n└ Most used combination: **${userOsu.modsData.mostCommonModCombination.combination}**`,
-                        inline: true
-                    }
-                )
-            }
-
-            if (!lastUpdate || (currentDate - lastUpdate) > 604800) {
-                buttons = new ActionRowBuilder().addComponents(
-                    new ButtonBuilder()
-                        .setLabel('🔄 Update your data')
-                        .setCustomId('refresh-osu-data')
-                        .setStyle('Primary'),
-                    new ButtonBuilder()
-                        .setLabel('🔄 Change your gamemode')
-                        .setCustomId('change-osu-mode')
-                        .setStyle('Primary')
-                )
-                osuEmbed.addFields(
-                    {
-                        name: "*You are able to update your analytics.*",
-                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:06:1195440954895765647><:08:1195440957735325707><:09:1195440958850998302><:11:1195441090677968936><:12:1195440961275306025><:14:1195441092947103847><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                    }
-                )
-            } else {
-                buttons = new ActionRowBuilder().addComponents(
-                    new ButtonBuilder()
-                        .setLabel('🔄 Update your data')
-                        .setCustomId('refresh-osu-data')
-                        .setStyle('Primary')
-                        .setDisabled(true),
-                    new ButtonBuilder()
-                        .setLabel('🔄 Change your gamemode')
-                        .setCustomId('change-osu-mode')
-                        .setStyle('Primary')
-                        .setDisabled(true)
-                )
-                osuEmbed.addFields(
-                    {
-                        name: `*You can update your analytics <t:${Math.floor(lastUpdate + 604800)}:R>.*`,
-                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:06:1195440954895765647><:08:1195440957735325707><:09:1195440958850998302><:11:1195441090677968936><:12:1195440961275306025><:14:1195441092947103847><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                    }
-                )
-            }
-
-            if (tier) {
-                osuEmbed.setFooter({ text: 'Endless Mirage | Collabs Profile | You\'re bump immune!', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-            } else {
-                osuEmbed.setFooter({ text: 'Endless Mirage | Collabs Profile', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-            }
-
-            const userPerks = await localFunctions.getPerks(userId, collection);
-            let collabsToJoinCount = 0;
-            const joinMenu = new SelectMenuBuilder()
-                .setCustomId('select-collab')
-                .setPlaceholder('Select a collab to join.')
-            const deluxeEntry = await localFunctions.getDeluxeEntry(userId, collection);
-            for (const collab of collabs) {
-                if (((collab.status !== "closed" && collab.status !== "on design") || userId === '687004886922952755') && typeof collabData.find(e => e.collabName === collab.name) === "undefined") {
-                    switch (collab.restriction) {
-                        case "staff":
-                            if (guildMember.roles.cache.has('961891383365500938') || userId === '687004886922952755') {
-                                joinMenu.addOptions({ label: collab.name, value: collab.name });
-                            }
-                            collabsToJoinCount++;
-                            break;
-                        case "deluxe":
-                            if (deluxeEntry || userId === '687004886922952755') {
-                                joinMenu.addOptions({ label: collab.name, value: collab.name });
-                            }
-                            collabsToJoinCount++;
-                            break;
-                        case "megacollab":
-                            if ((collab.status === "early access" && typeof userPerks.find(e => e.name === "Megacollab Early Access")) || userId === '687004886922952755') {
-                                joinMenu.addOptions({ label: collab.name, value: collab.name });
-                            } else if (collab.status === "open") {
-                                joinMenu.addOptions({ label: collab.name, value: collab.name });
-                            }
-                            collabsToJoinCount++;
-                            break;
-                        case "prestige":
-                            if (typeof prestige !== "undefined" || userId === '687004886922952755') {
-                                joinMenu.addOptions({ label: collab.name, value: collab.name });
-                            }
-                            collabsToJoinCount++;
-                            break;
-                        case "experimental":
-                            if (tier > 0 || prestigeLevel >= 4 || userId === '687004886922952755') {
-                                joinMenu.addOptions({ label: collab.name, value: collab.name });
-                            }
-                            collabsToJoinCount++;
-                            break;
-                        case "none":
-                            joinMenu.addOptions({ label: collab.name, value: collab.name });
-                            collabsToJoinCount++;
-                            break;
-                    }
-                }
-            }
-            const joinMenuRow = new ActionRowBuilder().addComponents(joinMenu);
-            if (collabData.length === 0) {
-                if (collabsToJoinCount === 0) {
-                    osuEmbed.setDescription(`**\`\`\`ml\n🏐 Welcome ${int.user.globalName}!\`\`\`**                                                                                     *Seems like you haven't joined any collab yet...*\n*Unfortunately, there isn't any collabs you can join at the moment.*`)
-                    await int.editReply({
-                        content: '',
-                        embeds: [osuEmbed],
-                        components: [buttons]
-                    })
-                } else {
-                    osuEmbed.setDescription(`**\`\`\`ml\n🏐 Welcome ${int.user.globalName}!\`\`\`**                                                                                     *Seems like you haven't joined any collab yet...*\n`)
-                    await int.editReply({
-                        content: '',
-                        embeds: [osuEmbed],
-                        components: [buttons, joinMenuRow]
-                    })
-                }
-            } else {
-                const manageMenu = new SelectMenuBuilder()
-                    .setCustomId('manage-collab')
-                    .setPlaceholder('Select a collab to manage.')
-                for (const currentCollab of collabData) {
-                    manageMenu.addOptions({ label: currentCollab.collabName, value: currentCollab.collabName });
-                }
-                const manageMenuRow = new ActionRowBuilder().addComponents(manageMenu);
-                if (collabsToJoinCount === 0) {
-                    osuEmbed.setDescription(`**\`\`\`ml\n🏐 Welcome ${int.user.globalName}!\`\`\`**                                                                                     *Unfortunately, there isn't any collabs you can join at the moment.*`);
-                    await int.editReply({
-                        content: '',
-                        embeds: [osuEmbed],
-                        components: [buttons, manageMenuRow]
-                    })
-                } else {
-                    osuEmbed.setDescription(`**\`\`\`ml\n🏐 Welcome ${int.user.globalName}!\`\`\`**                                                                                    `);
-                    await int.editReply({
-                        content: '',
-                        embeds: [osuEmbed],
-                        components: [buttons, manageMenuRow, joinMenuRow]
-                    })
-                }
-            }
-        } finally {
-            mongoClient.close();
-            mongoClientCollabs.close();
+            return;
         }
-    },
+
+        const collabData = await localFunctions.getUserCollabs(userId, collection);
+        const collabs = await localFunctions.getCollabs(collabCollection);
+        let buttons;
+
+        let tier = 0;
+        let prestigeLevel = 0;
+        let prestige = guildMember.roles.cache.find(role => localConstants.prestigeRolesIDs.includes(role.id));
+        if (typeof prestige !== "undefined") {
+            prestige = prestige.name
+
+            prestigeLevel = parseInt(prestige.replace('Prestige ', ''));
+        }
+        const userTier = await localFunctions.getUserTier(userId, collection);
+        if (userTier) {
+            tier = localFunctions.premiumToInteger(userTier.name);
+        } else if (guildMember.roles.cache.has('743505566617436301')) {
+            let premiumDetails = await localFunctions.assignPremium(userId, collection, guildMember);
+            tier = localFunctions.premiumToInteger(premiumDetails[0].name);
+        }
+
+        const osuEmbed = new EmbedBuilder()
+            .setColor('#f26e6a')
+            .setThumbnail(userOsu.avatar_url)
+            .addFields(
+                {
+                    name: "‎",
+                    value: `┌ Username: **${userOsu.username}**\n├ Country: **${tools.country(userOsu.country_code)}**\n├ Rank: **${userOsu.statistics.global_rank ? userOsu.statistics.global_rank : "Unranked"}**\n├ Peak Rank: **${userOsu.rank_highest.rank}**\n└ Level: **${userOsu.statistics.level.current}**`,
+                    inline: true
+                },
+                {
+                    name: "‎",
+                    value: `┌ Performance: **${userOsu.statistics.pp}pp**\n├ Join date: **<t:${new Date(userOsu.join_date).getTime() / 1000}:R>**\n├ Prestige Level: **${prestigeLevel}**\n├ Premium Tier: **${tier}**\n└ Playtime: **${Math.floor(userOsu.statistics.play_time / 3600)}h**`,
+                    inline: true
+                },
+                {
+                    name: "‎",
+                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:06:1195440954895765647><:08:1195440957735325707><:09:1195440958850998302><:11:1195441090677968936><:12:1195440961275306025><:14:1195441092947103847><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                },
+            )
+        if (typeof userOsu.skillRanks !== 'undefined') {
+            osuEmbed.addFields(
+                {
+                    name: "‎",
+                    value: `┌ ACC: **${userOsu.skillRanks[0].rank}** | Score: **${userOsu.skillRanks[0].int}**\n├ REA: **${userOsu.skillRanks[1].rank}** | Score: **${userOsu.skillRanks[1].int}**\n├ AIM: **${userOsu.skillRanks[2].rank}** | Score: **${userOsu.skillRanks[2].int}**\n├ SPD: **${userOsu.skillRanks[3].rank}** | Score: **${userOsu.skillRanks[3].int}**\n├ STA: **${userOsu.skillRanks[4].rank}** | Score: **${userOsu.skillRanks[4].int}**\n└ PRE: **${userOsu.skillRanks[5].rank}** | Score: **${userOsu.skillRanks[5].int}**`,
+                    inline: true
+                },
+                {
+                    name: "‎",
+                    value: `┌ Top 1 Mod: **${userOsu.modsData.top4Mods[0].mod}** | Usage: **${Math.round(userOsu.modsData.top4Mods[0].percentage)}%**\n├ Top 2 Mod: **${userOsu.modsData.top4Mods[1].mod}** | Usage: **${Math.round(userOsu.modsData.top4Mods[1].percentage)}%**\n├ Top 3 Mod: **${userOsu.modsData.top4Mods[2].mod}** | Usage: **${Math.round(userOsu.modsData.top4Mods[2].percentage)}%**\n├ Top 4 Mod: **${userOsu.modsData.top4Mods[3].mod}** | Usage: **${Math.round(userOsu.modsData.top4Mods[3].percentage) ? Math.round(userOsu.modsData.top4Mods[3].percentage) : userOsu.modsData.top4Mods[3].percentage}%**\n└ Most used combination: **${userOsu.modsData.mostCommonModCombination.combination}**`,
+                    inline: true
+                }
+            )
+        }
+
+        if (!lastUpdate || (currentDate - lastUpdate) > 604800) {
+            buttons = new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setLabel('🔄 Update your data')
+                    .setCustomId('refresh-osu-data')
+                    .setStyle('Primary'),
+                new ButtonBuilder()
+                    .setLabel('🔄 Change your gamemode')
+                    .setCustomId('change-osu-mode')
+                    .setStyle('Primary')
+            )
+            osuEmbed.addFields(
+                {
+                    name: "*You are able to update your analytics.*",
+                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:06:1195440954895765647><:08:1195440957735325707><:09:1195440958850998302><:11:1195441090677968936><:12:1195440961275306025><:14:1195441092947103847><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                }
+            )
+        } else {
+            buttons = new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setLabel('🔄 Update your data')
+                    .setCustomId('refresh-osu-data')
+                    .setStyle('Primary')
+                    .setDisabled(true),
+                new ButtonBuilder()
+                    .setLabel('🔄 Change your gamemode')
+                    .setCustomId('change-osu-mode')
+                    .setStyle('Primary')
+                    .setDisabled(true)
+            )
+            osuEmbed.addFields(
+                {
+                    name: `*You can update your analytics <t:${Math.floor(lastUpdate + 604800)}:R>.*`,
+                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:06:1195440954895765647><:08:1195440957735325707><:09:1195440958850998302><:11:1195441090677968936><:12:1195440961275306025><:14:1195441092947103847><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                }
+            )
+        }
+
+        if (tier) {
+            osuEmbed.setFooter({ text: 'Endless Mirage | Collabs Profile | You\'re bump immune!', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+        } else {
+            osuEmbed.setFooter({ text: 'Endless Mirage | Collabs Profile', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+        }
+
+        const userPerks = await localFunctions.getPerks(userId, collection);
+        let collabsToJoinCount = 0;
+        const joinMenu = new SelectMenuBuilder()
+            .setCustomId('select-collab')
+            .setPlaceholder('Select a collab to join.')
+        const deluxeEntry = await localFunctions.getDeluxeEntry(userId, collection);
+        for (const collab of collabs) {
+            if (((collab.status !== "closed" && collab.status !== "on design") || userId === '687004886922952755') && typeof collabData.find(e => e.collabName === collab.name) === "undefined") {
+                switch (collab.restriction) {
+                    case "staff":
+                        if (guildMember.roles.cache.has('961891383365500938') || userId === '687004886922952755') {
+                            joinMenu.addOptions({ label: collab.name, value: collab.name });
+                        }
+                        collabsToJoinCount++;
+                        break;
+                    case "deluxe":
+                        if (deluxeEntry || userId === '687004886922952755') {
+                            joinMenu.addOptions({ label: collab.name, value: collab.name });
+                        }
+                        collabsToJoinCount++;
+                        break;
+                    case "megacollab":
+                        if ((collab.status === "early access" && typeof userPerks.find(e => e.name === "Megacollab Early Access")) || userId === '687004886922952755') {
+                            joinMenu.addOptions({ label: collab.name, value: collab.name });
+                        } else if (collab.status === "open") {
+                            joinMenu.addOptions({ label: collab.name, value: collab.name });
+                        }
+                        collabsToJoinCount++;
+                        break;
+                    case "prestige":
+                        if (typeof prestige !== "undefined" || userId === '687004886922952755') {
+                            joinMenu.addOptions({ label: collab.name, value: collab.name });
+                        }
+                        collabsToJoinCount++;
+                        break;
+                    case "experimental":
+                        if (tier > 0 || prestigeLevel >= 4 || userId === '687004886922952755') {
+                            joinMenu.addOptions({ label: collab.name, value: collab.name });
+                        }
+                        collabsToJoinCount++;
+                        break;
+                    case "none":
+                        joinMenu.addOptions({ label: collab.name, value: collab.name });
+                        collabsToJoinCount++;
+                        break;
+                }
+            }
+        }
+        const joinMenuRow = new ActionRowBuilder().addComponents(joinMenu);
+        if (collabData.length === 0) {
+            if (collabsToJoinCount === 0) {
+                osuEmbed.setDescription(`**\`\`\`ml\n🏐 Welcome ${int.user.globalName}!\`\`\`**                                                                                     *Seems like you haven't joined any collab yet...*\n*Unfortunately, there isn't any collabs you can join at the moment.*`)
+                await int.editReply({
+                    content: '',
+                    embeds: [osuEmbed],
+                    components: [buttons]
+                })
+            } else {
+                osuEmbed.setDescription(`**\`\`\`ml\n🏐 Welcome ${int.user.globalName}!\`\`\`**                                                                                     *Seems like you haven't joined any collab yet...*\n`)
+                await int.editReply({
+                    content: '',
+                    embeds: [osuEmbed],
+                    components: [buttons, joinMenuRow]
+                })
+            }
+        } else {
+            const manageMenu = new SelectMenuBuilder()
+                .setCustomId('manage-collab')
+                .setPlaceholder('Select a collab to manage.')
+            for (const currentCollab of collabData) {
+                manageMenu.addOptions({ label: currentCollab.collabName, value: currentCollab.collabName });
+            }
+            const manageMenuRow = new ActionRowBuilder().addComponents(manageMenu);
+            if (collabsToJoinCount === 0) {
+                osuEmbed.setDescription(`**\`\`\`ml\n🏐 Welcome ${int.user.globalName}!\`\`\`**                                                                                     *Unfortunately, there isn't any collabs you can join at the moment.*`);
+                await int.editReply({
+                    content: '',
+                    embeds: [osuEmbed],
+                    components: [buttons, manageMenuRow]
+                })
+            } else {
+                osuEmbed.setDescription(`**\`\`\`ml\n🏐 Welcome ${int.user.globalName}!\`\`\`**                                                                                    `);
+                await int.editReply({
+                    content: '',
+                    embeds: [osuEmbed],
+                    components: [buttons, manageMenuRow, joinMenuRow]
+                });
+            }
+        }
+    }
 };

--- a/src/components/buttons/profile-pick.js
+++ b/src/components/buttons/profile-pick.js
@@ -1,6 +1,5 @@
 const { EmbedBuilder } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { buttonCache } = require('../selectMenus/select-collab');
@@ -13,10 +12,12 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+
         const guild = client.guilds.cache.get(localConstants.guildId);
         const guildMember = guild.members.cache.get(userId);
+        
         try {
             const userCollabs = await localFunctions.getUserCollabs(userId, userCollection);
             const userCollab = userCollabs.find(e => e.collabName === buttonCache.get(userId).collab);
@@ -190,9 +191,6 @@ module.exports = {
         } catch (e) {
             console.log(e)
             await int.editReply('Something went wrong...')
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
         }
     },
     profileButtonCache: profileButtonCache

--- a/src/components/buttons/reject-trade.js
+++ b/src/components/buttons/reject-trade.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -11,7 +10,7 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB('Special');
+        const collectionSpecial = client.db.collection("Special");
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         try {
@@ -83,8 +82,6 @@ module.exports = {
             }
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClientSpecial.close();
         }
     }
 }

--- a/src/components/buttons/reset-collab.js
+++ b/src/components/buttons/reset-collab.js
@@ -1,7 +1,7 @@
 const { TextInputStyle } = require('discord.js');
 const { ActionRowBuilder, ModalBuilder, TextInputBuilder } = require('@discordjs/builders');
 const { collabCache } = require('./admin-collab');
-const { adminCache }= require('../../commands/collabs/collabs');
+const { adminCache } = require('../../commands/collabs/collabs');
 const resetCache = new Map();
 
 module.exports = {

--- a/src/components/buttons/see-referrals.js
+++ b/src/components/buttons/see-referrals.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -12,8 +11,9 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("OzenCollection");
+        const collabCollection = client.db.collection("Collabs");
+
         try {
             const referralCode = await localFunctions.getUserReferral(userId, collection);
             if (!referralCode) return int.editReply('You don\'t have a referral code...');
@@ -59,9 +59,6 @@ module.exports = {
 
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
-            mongoClientCollabs.close();
         }
     }
-}
+};

--- a/src/components/buttons/shopping-cart.js
+++ b/src/components/buttons/shopping-cart.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
 const { SelectMenuBuilder, ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
@@ -11,62 +10,59 @@ module.exports = {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
         let totalCost = 0;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
         const cartEmbed = new EmbedBuilder()
             .setFooter({ text: 'Endless Mirage | Premium Dashboard', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-            .setColor('#f26e6a')
-        try {
-            let cartItems = await localFunctions.getCart(userId, collection);
-            if (cartItems.length) {
-                let deleteMenu = new SelectMenuBuilder()
-                    .setCustomId('delete-cart-items')
-                    .setPlaceholder('Remove specific items from the cart.')
-                    .setMinValues(1)
-                    .setMaxValues(cartItems.length);
-                let itemString = '';
-                for (let item of cartItems) {
-                    itemString = itemString.concat(`**\`\`🔗 ${item.name}\`\`**\n ├ Type: ${item.type}\n └ Price: ${item.price}$\n\n`)
-                    totalCost = totalCost + item.price;
-                    deleteMenu.addOptions({ label: item.name, value: item.name, description: `Cost: ${item.price}$` });
-                }
-                cartEmbed.setDescription(`**\`\`\`prolog\n🛒 Current items in cart\`\`\`**                                                                                                           \n${itemString}`)
-                cartEmbed.addFields(
-                    {
-                        name: "‎",
-                        value: `**\`\`\`ml\n💳 Total cost: ${totalCost}$\`\`\`**`,
-                    },
-                )
-                const deleteComponent = new ActionRowBuilder().addComponents(deleteMenu);
-                let cartComponents = new ActionRowBuilder().addComponents(
-                    new ButtonBuilder()
-                        .setCustomId('checkout')
-                        .setLabel('💵 Checkout')
-                        .setStyle('Success'),
-                    new ButtonBuilder()
-                        .setCustomId('empty-cart')
-                        .setLabel('🚮 Empty cart')
-                        .setStyle('Danger'),
-                )
-                cartEmbed.addFields(
-                    {
-                        name: "‎",
-                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                    }
-                )
-                await int.editReply({
-                    content: '',
-                    embeds: [cartEmbed],
-                    components: [cartComponents, deleteComponent],
-                });
-            } else {
-                cartEmbed.setDescription("**\`\`\`ml\n🛒 Your cart is empty!\`\`\`**\n                                                                                                           \n*Add some content!*")
-                await int.editReply({
-                    content: '',
-                    embeds: [cartEmbed],
-                });
+            .setColor('#f26e6a');
+        
+        let cartItems = await localFunctions.getCart(userId, collection);
+        if (cartItems.length) {
+            let deleteMenu = new SelectMenuBuilder()
+                .setCustomId('delete-cart-items')
+                .setPlaceholder('Remove specific items from the cart.')
+                .setMinValues(1)
+                .setMaxValues(cartItems.length);
+            let itemString = '';
+            for (let item of cartItems) {
+                itemString = itemString.concat(`**\`\`🔗 ${item.name}\`\`**\n ├ Type: ${item.type}\n └ Price: ${item.price}$\n\n`)
+                totalCost = totalCost + item.price;
+                deleteMenu.addOptions({ label: item.name, value: item.name, description: `Cost: ${item.price}$` });
             }
-        } finally {
-            mongoClient.close();
+            cartEmbed.setDescription(`**\`\`\`prolog\n🛒 Current items in cart\`\`\`**                                                                                                           \n${itemString}`)
+            cartEmbed.addFields(
+                {
+                    name: "‎",
+                    value: `**\`\`\`ml\n💳 Total cost: ${totalCost}$\`\`\`**`,
+                },
+            )
+            const deleteComponent = new ActionRowBuilder().addComponents(deleteMenu);
+            let cartComponents = new ActionRowBuilder().addComponents(
+                new ButtonBuilder()
+                    .setCustomId('checkout')
+                    .setLabel('💵 Checkout')
+                    .setStyle('Success'),
+                new ButtonBuilder()
+                    .setCustomId('empty-cart')
+                    .setLabel('🚮 Empty cart')
+                    .setStyle('Danger'),
+            )
+            cartEmbed.addFields(
+                {
+                    name: "‎",
+                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                }
+            )
+            await int.editReply({
+                content: '',
+                embeds: [cartEmbed],
+                components: [cartComponents, deleteComponent],
+            });
+        } else {
+            cartEmbed.setDescription("**\`\`\`ml\n🛒 Your cart is empty!\`\`\`**\n                                                                                                           \n*Add some content!*")
+            await int.editReply({
+                content: '',
+                embeds: [cartEmbed],
+            });
         }
     }
-}
+};

--- a/src/components/buttons/snipe-pick.js
+++ b/src/components/buttons/snipe-pick.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { userCheckCache } = require('../../commands/collabs/collabs');
 const { userCheckCacheModal } = require('../modals/check-pick');
@@ -11,9 +10,9 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB('Special');
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+        const collectionSpecial = client.db.collection("Special");
         let initializedMap;
         if (userCheckCache.size > 0) {
             if (typeof userCheckCache.get(int.user.id) !== "undefined") {
@@ -58,10 +57,6 @@ module.exports = {
             await int.editReply('A notification if this pick becomes available will be sent to you! If the character becomes available and it gets picked by someone else, your would need to run this command again to get another notification.');
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
-            mongoClientSpecial.close();
         }
     }
 }

--- a/src/components/buttons/sub-manage.js
+++ b/src/components/buttons/sub-manage.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -10,7 +9,7 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
         const userId = int.user.id;
         let renewalString = '';
         const currentDate = new Date();
@@ -31,85 +30,81 @@ module.exports = {
             .setAuthor({ name: `Welcome to your subscription dashboard ${int.user.tag}!`, iconURL: 'https://puu.sh/JYyyk/5bad2f94ad.png' })
             .setFooter({ text: 'Endless Mirage | Subscription Dashboard', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
 
-        try {
-            let subStatus = await localFunctions.getUserMontlyPremium(userId, collection);
-            let dbTier = await localFunctions.getTier(userId, collection);
-            let fullTier = localConstants.premiumTiers.find((e) => e.name === dbTier.name);
-            let fullTierRenewal = fullTier.generalRenewalPrice;
-            if (fullTierRenewal) {
-                if (parseInt(subStatus.total) >= fullTierRenewal) {
-                    renewalString = '**\nYour current status renews all of your perks! How awesome.**'
-                } else {
-                    renewalString = `Current amount pending for permanent perk renewal = ${fullTierRenewal - parseInt(subStatus.total)}$`
-                }
+        let subStatus = await localFunctions.getUserMontlyPremium(userId, collection);
+        let dbTier = await localFunctions.getTier(userId, collection);
+        let fullTier = localConstants.premiumTiers.find((e) => e.name === dbTier.name);
+        let fullTierRenewal = fullTier.generalRenewalPrice;
+        if (fullTierRenewal) {
+            if (parseInt(subStatus.total) >= fullTierRenewal) {
+                renewalString = '**\nYour current status renews all of your perks! How awesome.**'
             } else {
-                renewalString = `Your perks are renewed because of your current Mirage Tier! Thank you for supporting us despite the fact of having the peak tier <3`
+                renewalString = `Current amount pending for permanent perk renewal = ${fullTierRenewal - parseInt(subStatus.total)}$`
             }
+        } else {
+            renewalString = `Your perks are renewed because of your current Mirage Tier! Thank you for supporting us despite the fact of having the peak tier <3`
+        }
 
-            let buyComponents = new ActionRowBuilder().addComponents(
-                new ButtonBuilder()
-                    .setCustomId('sub-change-amount')
-                    .setLabel('💵 Change your Monthly Amount')
-                    .setStyle('Primary'),
-            )
-            buyEmbed.setDescription(`**Current Tier: ${dbTier.name}**`);
+        let buyComponents = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId('sub-change-amount')
+                .setLabel('💵 Change your Monthly Amount')
+                .setStyle('Primary'),
+        )
+        buyEmbed.setDescription(`**Current Tier: ${dbTier.name}**`);
 
-            const startingDateParts = subStatus.startingDate.split("/");
-            const lastPaymentParts = subStatus.lastDate.split("/");
+        const startingDateParts = subStatus.startingDate.split("/");
+        const lastPaymentParts = subStatus.lastDate.split("/");
 
-            const startingDate = new Date(startingDateParts[2], startingDateParts[1] - 1, startingDateParts[0]); 
-            const lastPayment = new Date(lastPaymentParts[2], lastPaymentParts[1] - 1, lastPaymentParts[0]); 
+        const startingDate = new Date(startingDateParts[2], startingDateParts[1] - 1, startingDateParts[0]); 
+        const lastPayment = new Date(lastPaymentParts[2], lastPaymentParts[1] - 1, lastPaymentParts[0]); 
 
-            const monthsDiff = (lastPayment.getFullYear() - startingDate.getFullYear()) * 12 + lastPayment.getMonth() - startingDate.getMonth();
+        const monthsDiff = (lastPayment.getFullYear() - startingDate.getFullYear()) * 12 + lastPayment.getMonth() - startingDate.getMonth();
+        buyEmbed.addFields(
+            {
+                name: " ",
+                value: `**\`\`\`prolog\n💵 Subscription Info\`\`\`**\n**Current Donated Amount:** ${subStatus.total}$\n**Current Monthly Amount:** ${subStatus.currentAmount}$\n**Starting Date:** ${subStatus.startingDate}\n**Last Payment:** ${subStatus.lastDate}\n**Total Months:** ${monthsDiff}\n${renewalString}\nNext Payment Window: ${localConstants.startingSubDay}/${formattedMonth}/${year} - ${localConstants.finalSubDay}/${formattedMonth}/${year}`,
+            }
+        )
+
+        if (subStatus.status === "paid") {
             buyEmbed.addFields(
                 {
                     name: " ",
-                    value: `**\`\`\`prolog\n💵 Subscription Info\`\`\`**\n**Current Donated Amount:** ${subStatus.total}$\n**Current Monthly Amount:** ${subStatus.currentAmount}$\n**Starting Date:** ${subStatus.startingDate}\n**Last Payment:** ${subStatus.lastDate}\n**Total Months:** ${monthsDiff}\n${renewalString}\nNext Payment Window: ${localConstants.startingSubDay}/${formattedMonth}/${year} - ${localConstants.finalSubDay}/${formattedMonth}/${year}`,
+                    value: `**\`\`\`prolog\n💵 Payments are up to date!\`\`\`**\n`
                 }
             )
-
-            if (subStatus.status === "paid") {
-                buyEmbed.addFields(
-                    {
-                        name: " ",
-                        value: `**\`\`\`prolog\n💵 Payments are up to date!\`\`\`**\n`
-                    }
-                )
-            } else {
-                buyEmbed.addFields(
-                    {
-                        name: " ",
-                        value: `**\`\`\`prolog\n💵 Payment for this month is Pending!\`\`\`**\nUse the renew button bellow to solve this!`,
-                    }
-                )
-                buyComponents.addComponents(
-                    new ButtonBuilder()
-                        .setCustomId('sub-renew')
-                        .setLabel('💵 Renew')
-                        .setStyle('Success'),
-                )
-            }
-
-            buyComponents.addComponents(
-                new ButtonBuilder()
-                    .setCustomId('sub-cancel')
-                    .setLabel('💵 Cancel')
-                    .setStyle('Danger'),
-            )
-
+        } else {
             buyEmbed.addFields(
                 {
-                    name: "‎",
-                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                    name: " ",
+                    value: `**\`\`\`prolog\n💵 Payment for this month is Pending!\`\`\`**\nUse the renew button bellow to solve this!`,
                 }
             )
-            await int.editReply({
-                content: '',
-                embeds: [buyEmbed],
-                components: [buyComponents],
-            });
-        } finally {
-            mongoClient.close();
+            buyComponents.addComponents(
+                new ButtonBuilder()
+                    .setCustomId('sub-renew')
+                    .setLabel('💵 Renew')
+                    .setStyle('Success'),
+            )
         }
-    },
-}
+
+        buyComponents.addComponents(
+            new ButtonBuilder()
+                .setCustomId('sub-cancel')
+                .setLabel('💵 Cancel')
+                .setStyle('Danger'),
+        )
+
+        buyEmbed.addFields(
+            {
+                name: "‎",
+                value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+            }
+        )
+        await int.editReply({
+            content: '',
+            embeds: [buyEmbed],
+            components: [buyComponents],
+        });
+    }
+};

--- a/src/components/buttons/sub-renew.js
+++ b/src/components/buttons/sub-renew.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -11,7 +10,7 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
         const checkoutEmbed = new EmbedBuilder()
             .setFooter({ text: 'Endless Mirage', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
             .setColor('#f26e6a')
@@ -61,8 +60,6 @@ module.exports = {
             });
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
         }
     }
 }

--- a/src/components/buttons/swap-image-approve.js
+++ b/src/components/buttons/swap-image-approve.js
@@ -1,7 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
-const { connectToMongoDB } = require('../../mongo');
 
 module.exports = {
     data: {
@@ -16,41 +15,35 @@ module.exports = {
         if (typeof request === "undefined") return int.editReply('Something went wrong...');
 
         const newImgURL = request.imgURL;
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
-        try {
-            await localFunctions.editPickImage(request.pickId, request.user, request.collab, collabCollection, userCollection, newImgURL);
-            const logChannel = guild.channels.cache.get(localConstants.logChannelID);
-            let imageSwapEmbed = new EmbedBuilder()
-                .setFooter({ text: "Endless Mirage | Accepted Request", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setTimestamp()
-                .setImage(request.imgURL)
-                .setURL('https://endlessmirage.net/')
-                .setDescription(`**\`\`\`🏐 Accepted Image Request!\`\`\`**`)
-                .addFields(
-                    {
-                        name: request.embed.data.fields[0].name,
-                        value: request.embed.data.fields[0].value
-                    },
-                    {
-                        name: request.embed.data.fields[1].name,
-                        value: request.embed.data.fields[1].value
-                    }
-                )
+        const userCollection = client.db.collection("OzenCollection");
+        const collabCollection = client.db.collection("Collabs");
 
-            let oldImageEmbed = new EmbedBuilder()
-                .setURL('https://endlessmirage.net/')
-                .setImage(request.oldImgURL)
-            await int.message.edit({ embeds: [imageSwapEmbed, oldImageEmbed], components: [] });
-            await logChannel.send({ content: `<@${request.user}> Your image change request has been accepted!`, embeds: [imageSwapEmbed, oldImageEmbed] });
-            await localFunctions.liquidateImageRequest(request._id);
-            await int.editReply({ content: 'Request successfully accepted.', ephemeral: true });
+        await localFunctions.editPickImage(request.pickId, request.user, request.collab, collabCollection, userCollection, newImgURL);
+        const logChannel = guild.channels.cache.get(localConstants.logChannelID);
+        let imageSwapEmbed = new EmbedBuilder()
+            .setFooter({ text: "Endless Mirage | Accepted Request", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setTimestamp()
+            .setImage(request.imgURL)
+            .setURL('https://endlessmirage.net/')
+            .setDescription(`**\`\`\`🏐 Accepted Image Request!\`\`\`**`)
+            .addFields(
+                {
+                    name: request.embed.data.fields[0].name,
+                    value: request.embed.data.fields[0].value
+                },
+                {
+                    name: request.embed.data.fields[1].name,
+                    value: request.embed.data.fields[1].value
+                }
+            );
 
-        } finally {
-            mongoClientUsers.close();
-            mongoClientCollabs.close();
-        }
-
-    },
+        let oldImageEmbed = new EmbedBuilder()
+            .setURL('https://endlessmirage.net/')
+            .setImage(request.oldImgURL)
+        await int.message.edit({ embeds: [imageSwapEmbed, oldImageEmbed], components: [] });
+        await logChannel.send({ content: `<@${request.user}> Your image change request has been accepted!`, embeds: [imageSwapEmbed, oldImageEmbed] });
+        await localFunctions.liquidateImageRequest(request._id);
+        await int.editReply({ content: 'Request successfully accepted.', ephemeral: true });
+    }
 };

--- a/src/components/buttons/trade-user.js
+++ b/src/components/buttons/trade-user.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
@@ -14,8 +13,8 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB('Special');
+        const userCollection = client.db.collection("OzenCollection");
+        const collectionSpecial = client.db.collection("Special");
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         let initializedMap;
@@ -126,9 +125,6 @@ module.exports = {
 
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClientUsers.close();
-            mongoClientSpecial.close();
         }
     }
 }

--- a/src/components/buttons/upgrade-tier.js
+++ b/src/components/buttons/upgrade-tier.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -13,83 +12,79 @@ module.exports = {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
         let arrayOfObjects = [];
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
 
-        try {
-            const staticTier = await localFunctions.getUserTier(userId, collection) || [];
-            let userTier = staticTier;
-            const fullTier = localConstants.premiumTiers.find(obj => obj.name === staticTier.name);
-            for (const numeral of localConstants.romanNumerals) {
-                const roleToFind = `Mirage ${numeral}`;
-                if (roleToFind === userTier.name) {
-                    userTier = localFunctions.romanToInteger(numeral);
-                }
+        const staticTier = await localFunctions.getUserTier(userId, collection) || [];
+        let userTier = staticTier;
+        const fullTier = localConstants.premiumTiers.find(obj => obj.name === staticTier.name);
+        for (const numeral of localConstants.romanNumerals) {
+            const roleToFind = `Mirage ${numeral}`;
+            if (roleToFind === userTier.name) {
+                userTier = localFunctions.romanToInteger(numeral);
             }
-            let upgradeablePerks = [];
-            for (const tiers of localConstants.premiumTiers) {
-                if (tiers.id > userTier) {
-                    upgradeablePerks.push(tiers)
-                }
-            }
-
-            const tiersEmbed = new EmbedBuilder()
-                .setColor('#f26e6a')
-                .setFooter({ text: 'Endless Mirage | Premium Dashboard', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setDescription("**\`\`\`ml\n🚀 Upgrade your tier\`\`\`**                                                                                                        **\n • Bellow you can find the tiers your can upgrade to with their prices adapted to your current tier.\n • By upgrading, you will get all of the perks of the tier and the ones bellow renewed.**")
-
-            if (upgradeablePerks.length !== 0) {
-                let buyMenu = new SelectMenuBuilder()
-                    .setCustomId('add-content-to-cart')
-                    .setPlaceholder('Choose the tier you want to upgrade to.')  
-
-                for (const tier of upgradeablePerks) {
-                        tiersEmbed.addFields(
-                            {
-                                name: "‎",
-                                value: `\`\`✒️ ${tier.name}\`\`\n └ **Upgrade cost: ${tier.cost-fullTier.cost}$**`,
-                                inline: true,
-                            }
-                        )
-                        buyMenu.addOptions({ label: tier.name, value: `${tier.name}`, description: `Upgrade cost: ${tier.cost-fullTier.cost}$` });
-                        arrayOfObjects.push({ name: tier.name, type: 'Upgrade', price: tier.cost-fullTier.cost });
-                }
-                const Components = new ActionRowBuilder().addComponents(buyMenu);
-                tiersEmbed.addFields(
-                    {
-                        name: "‎",
-                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                    }
-                )
-                await int.editReply({
-                    content: '',
-                    embeds: [tiersEmbed],
-                    components: [Components],
-                });
-            } else {
-                tiersEmbed.addFields(
-                    {
-                        name: "‎",
-                        value: "\`\`✒️ You have the peak tier!\`\`",
-                    }
-                )
-                tiersEmbed.addFields(
-                    {
-                        name: "‎",
-                        value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
-                    }
-                )
-                await int.editReply({
-                    content: '',
-                    embeds: [tiersEmbed],
-                });
-            }
-
-            upgradeCache.set(int.user.id, {
-                choices: arrayOfObjects,
-            });
-        } finally {
-            mongoClient.close();
         }
+        let upgradeablePerks = [];
+        for (const tiers of localConstants.premiumTiers) {
+            if (tiers.id > userTier) {
+                upgradeablePerks.push(tiers)
+            }
+        }
+
+        const tiersEmbed = new EmbedBuilder()
+            .setColor('#f26e6a')
+            .setFooter({ text: 'Endless Mirage | Premium Dashboard', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setDescription("**\`\`\`ml\n🚀 Upgrade your tier\`\`\`**                                                                                                        **\n • Bellow you can find the tiers your can upgrade to with their prices adapted to your current tier.\n • By upgrading, you will get all of the perks of the tier and the ones bellow renewed.**")
+
+        if (upgradeablePerks.length !== 0) {
+            let buyMenu = new SelectMenuBuilder()
+                .setCustomId('add-content-to-cart')
+                .setPlaceholder('Choose the tier you want to upgrade to.')  
+
+            for (const tier of upgradeablePerks) {
+                    tiersEmbed.addFields(
+                        {
+                            name: "‎",
+                            value: `\`\`✒️ ${tier.name}\`\`\n └ **Upgrade cost: ${tier.cost-fullTier.cost}$**`,
+                            inline: true,
+                        }
+                    )
+                    buyMenu.addOptions({ label: tier.name, value: `${tier.name}`, description: `Upgrade cost: ${tier.cost-fullTier.cost}$` });
+                    arrayOfObjects.push({ name: tier.name, type: 'Upgrade', price: tier.cost-fullTier.cost });
+            }
+            const Components = new ActionRowBuilder().addComponents(buyMenu);
+            tiersEmbed.addFields(
+                {
+                    name: "‎",
+                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                }
+            )
+            await int.editReply({
+                content: '',
+                embeds: [tiersEmbed],
+                components: [Components],
+            });
+        } else {
+            tiersEmbed.addFields(
+                {
+                    name: "‎",
+                    value: "\`\`✒️ You have the peak tier!\`\`",
+                }
+            )
+            tiersEmbed.addFields(
+                {
+                    name: "‎",
+                    value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:18:1195440968007176333><:19:1195441100350034063><:20:1195441101201494037><:21:1195441102585606144><:22:1195441104498212916><:23:1195440971886903356><:24:1195441154674675712><:25:1195441155664527410><:26:1195441158155931768><:27:1195440974978093147>",
+                }
+            )
+            await int.editReply({
+                content: '',
+                embeds: [tiersEmbed],
+            });
+        }
+
+        upgradeCache.set(int.user.id, {
+            choices: arrayOfObjects,
+        });
     },
     upgradeCache: upgradeCache
-}
+};

--- a/src/components/buttons/verify-osu.js
+++ b/src/components/buttons/verify-osu.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
@@ -12,8 +11,9 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         const userId = int.user.id;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: blacklistCollection, client: mongoClientBlacklist } = await connectToMongoDB("Blacklist");
+        const collection = client.db.collection("OzenCollection");
+        const blacklistCollection = client.db.collection("Blacklist");
+        
         try {
             let verificationCode = 0;
             let osu_user_full = [];
@@ -63,9 +63,6 @@ module.exports = {
             })
         } catch {
             await int.editReply('Something went wrong, most likely the bot just got reset while you were trying this interaction. Please try to verify from the beggining again.')
-        } finally {
-            mongoClient.close();
-            mongoClientBlacklist.close();
         }
-    },
-}
+    }
+};

--- a/src/components/buttons/verify-payment-sub.js
+++ b/src/components/buttons/verify-payment-sub.js
@@ -21,4 +21,4 @@ module.exports = {
 
         await int.showModal(modal);
     }
-}
+};

--- a/src/components/buttons/verify-payment.js
+++ b/src/components/buttons/verify-payment.js
@@ -21,4 +21,4 @@ module.exports = {
 
         await int.showModal(modal);
     }
-}
+};

--- a/src/components/modals/blacklist-user-collab-admin.js
+++ b/src/components/modals/blacklist-user-collab-admin.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { collabCache } = require('./manage-pick-collab');
@@ -21,62 +20,59 @@ module.exports = {
                 initializedMap = userCheckCache;
             }
         }
-        await int.deferReply({ephemeral: true});
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: blacklistCollection, client: mongoClientBlacklist } = await connectToMongoDB("Blacklist");
+        await int.deferReply({ ephemeral: true });
+        
+        // MongoDB collections.
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+        const blacklistCollection = client.db.collection("Blacklist");
+
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         const auditChannel = guild.channels.cache.get(localConstants.auditLogChannelID);
 
-        try {
-            const collab = initializedMap.get(int.user.id).collab;
-            const pickFull = initializedMap.get(int.user.id).pick;
-            let participants = collab.participants;
-            const id = pickFull.id;
-            const fullParticipation = participants.find((e) => e.id === id);
+        const collab = initializedMap.get(int.user.id).collab;
+        const pickFull = initializedMap.get(int.user.id).pick;
+        let participants = collab.participants;
+        const id = pickFull.id;
+        const fullParticipation = participants.find((e) => e.id === id);
 
-            await localFunctions.setBlacklist(fullParticipation.discordId, int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None", fullParticipation.osu_id, blacklistCollection);
-            let userCollabs = await localFunctions.getUserCollabs(fullParticipation.discordId, userCollection);
-            await localFunctions.unsetCollabParticipation(collab.name, collection, id);
-            userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
-            await localFunctions.setUserCollabs(fullParticipation.discordId, userCollabs, userCollection);
-            await localFunctions.removeCollabParticipant(collab.name, collection, fullParticipation.discordId);
-            await localFunctions.unsetParticipationOnSheet(collab, pickFull);
-            await localFunctions.liquidateUserOsuData(fullParticipation.discordId, userCollection);
+        await localFunctions.setBlacklist(fullParticipation.discordId, int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None", fullParticipation.osu_id, blacklistCollection);
+        let userCollabs = await localFunctions.getUserCollabs(fullParticipation.discordId, userCollection);
+        await localFunctions.unsetCollabParticipation(collab.name, collection, id);
+        userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
+        await localFunctions.setUserCollabs(fullParticipation.discordId, userCollabs, userCollection);
+        await localFunctions.removeCollabParticipant(collab.name, collection, fullParticipation.discordId);
+        await localFunctions.unsetParticipationOnSheet(collab, pickFull);
+        await localFunctions.liquidateUserOsuData(fullParticipation.discordId, userCollection);
 
-            const pendingMember = await guild.members.fetch(fullParticipation.discordId);
-            await pendingMember.roles.remove(collab.roleId);
+        const pendingMember = await guild.members.fetch(fullParticipation.discordId);
+        await pendingMember.roles.remove(collab.roleId);
 
-            let contentString = "";
-            const snipes = collab.snipes;
-            if (typeof snipes !== "undefined") {
-                if (typeof snipes.find(p => p.pick === id) !== "undefined") {
-                    contentString = "Snipers! ";
-                }
-                for (const snipe of snipes) {
-                    contentString = contentString.concat('', `<@${snipe.userId}>`);
-                    await localFunctions.removeCollabSnipe(collab.name, collection, snipe.userId);
-                }
+        let contentString = "";
+        const snipes = collab.snipes;
+        if (typeof snipes !== "undefined") {
+            if (typeof snipes.find(p => p.pick === id) !== "undefined") {
+                contentString = "Snipers! ";
             }
-
-            const leaveEmbed = new EmbedBuilder()
-                .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setDescription(`**\`\`\`ml\n📣 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${pickFull.name}\nID: ${pickFull.id}`)
-                .setImage(pickFull.imgURL)
-            logChannel.send({ content: `${contentString}\nUser <@${fullParticipation.discordId}> has been blacklisted from the collabs.\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Removed by:** <@${int.user.id}>`, embeds: [leaveEmbed] });
-
-            const auditEmbed = new EmbedBuilder()
-                .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An user has been blacklisted!**\n\n**Pick Name**: ${pickFull.name}\n**Pick ID**: ${pickFull.id}\n**Ex-Owner**: <@${fullParticipation.discordId}>\n**Removed by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
-            auditChannel.send({ content: '', embeds: [auditEmbed] });
-            await int.editReply('The user has been blacklisted.');
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
-            mongoClientBlacklist.close();
+            for (const snipe of snipes) {
+                contentString = contentString.concat('', `<@${snipe.userId}>`);
+                await localFunctions.removeCollabSnipe(collab.name, collection, snipe.userId);
+            }
         }
-    },
+
+        const leaveEmbed = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setDescription(`**\`\`\`ml\n📣 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${pickFull.name}\nID: ${pickFull.id}`)
+            .setImage(pickFull.imgURL)
+        logChannel.send({ content: `${contentString}\nUser <@${fullParticipation.discordId}> has been blacklisted from the collabs.\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Removed by:** <@${int.user.id}>`, embeds: [leaveEmbed] });
+
+        const auditEmbed = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An user has been blacklisted!**\n\n**Pick Name**: ${pickFull.name}\n**Pick ID**: ${pickFull.id}\n**Ex-Owner**: <@${fullParticipation.discordId}>\n**Removed by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
+        auditChannel.send({ content: '', embeds: [auditEmbed] });
+        await int.editReply('The user has been blacklisted.');
+    }
 };

--- a/src/components/modals/blacklist-user-report.js
+++ b/src/components/modals/blacklist-user-report.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { reportCache } = require('../buttons/report-accept');
@@ -10,96 +9,92 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: blacklistCollection, client: mongoClientBlacklist } = await connectToMongoDB("Blacklist");
+        
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+        const blacklistCollection = client.db.collection("Blacklist");
+
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         const auditChannel = guild.channels.cache.get(localConstants.auditLogChannelID);
 
-        try {
-            const report = reportCache.get(int.user.id).report;
-            const collab = await localFunctions.getCollab(report.collab, collection);
-            const pickFull = collab.pool.items.find(e => e.id === report.pickId);
-            const message = reportCache.get(int.user.id).message;
-            const id = pickFull.id;
-            const fullParticipation = collab.participants.find((e) => e.id === id);
+        const report = reportCache.get(int.user.id).report;
+        const collab = await localFunctions.getCollab(report.collab, collection);
+        const pickFull = collab.pool.items.find(e => e.id === report.pickId);
+        const message = reportCache.get(int.user.id).message;
+        const id = pickFull.id;
+        const fullParticipation = collab.participants.find((e) => e.id === id);
 
-            await localFunctions.setBlacklist(fullParticipation.discordId, int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None", fullParticipation.osu_id, blacklistCollection);
-            let userCollabs = await localFunctions.getUserCollabs(fullParticipation.discordId, userCollection);
-            await localFunctions.unsetCollabParticipation(collab.name, collection, id);
-            userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
-            await localFunctions.setUserCollabs(fullParticipation.discordId, userCollabs, userCollection);
-            await localFunctions.removeCollabParticipant(collab.name, collection, fullParticipation.discordId);
-            await localFunctions.unsetParticipationOnSheet(collab, pickFull);
-            await localFunctions.liquidateUserOsuData(fullParticipation.discordId, userCollection);
+        await localFunctions.setBlacklist(fullParticipation.discordId, int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None", fullParticipation.osu_id, blacklistCollection);
+        let userCollabs = await localFunctions.getUserCollabs(fullParticipation.discordId, userCollection);
+        await localFunctions.unsetCollabParticipation(collab.name, collection, id);
+        userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
+        await localFunctions.setUserCollabs(fullParticipation.discordId, userCollabs, userCollection);
+        await localFunctions.removeCollabParticipant(collab.name, collection, fullParticipation.discordId);
+        await localFunctions.unsetParticipationOnSheet(collab, pickFull);
+        await localFunctions.liquidateUserOsuData(fullParticipation.discordId, userCollection);
 
-            const pendingMember = await guild.members.fetch(fullParticipation.discordId);
-            await pendingMember.roles.remove(collab.roleId);
+        const pendingMember = await guild.members.fetch(fullParticipation.discordId);
+        await pendingMember.roles.remove(collab.roleId);
 
 
-            let contentString = "";
-            const snipes = collab.snipes;
-            if (typeof snipes !== "undefined") {
-                if (typeof snipes.find(p => p.pick === id) !== "undefined") {
-                    contentString = "Snipers! ";
-                }
-                for (const snipe of snipes) {
-                    contentString = contentString.concat('', `<@${snipe.userId}>`);
-                    await localFunctions.removeCollabSnipe(collab.name, collection, snipe.userId);
-                }
+        let contentString = "";
+        const snipes = collab.snipes;
+        if (typeof snipes !== "undefined") {
+            if (typeof snipes.find(p => p.pick === id) !== "undefined") {
+                contentString = "Snipers! ";
             }
-
-            const leaveEmbed = new EmbedBuilder()
-                .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setDescription(`**\`\`\`ml\n📣 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${pickFull.name}\nID: ${pickFull.id}`)
-                .setImage(pickFull.imgURL)
-            logChannel.send({ content: `${contentString}\nUser <@${fullParticipation.discordId}> has been blacklisted from the collabs.\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Removed by:** <@${int.user.id}>`, embeds: [leaveEmbed] });
-
-            const auditEmbed = new EmbedBuilder()
-                .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An user has been blacklisted!**\n\n**Pick Name**: ${pickFull.name}\n**Pick ID**: ${pickFull.id}\n**Ex-Owner**: <@${fullParticipation.discordId}>\n**Removed by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
-            auditChannel.send({ content: '', embeds: [auditEmbed] });
-
-            let reportEmbed = new EmbedBuilder()
-                .setFooter({ text: "Endless Mirage | Report Accepted", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setTimestamp()
-                .setURL('https://endlessmirage.net/')
-                .setDescription(`**\`\`\`📣 Report Accepted\`\`\`**\n**Action taken:** Blacklist\n**Admin:** <@${int.user.id}>`)
-                .addFields(
-                    {
-                        name: report.embed.data.fields[0].name,
-                        value: report.embed.data.fields[0].value
-                    },
-                    {
-                        name: report.embed.data.fields[1].name,
-                        value: report.embed.data.fields[1].value
-                    }
-                )
-
-            const reporterMember = await guild.members.cache.find(member => member.id === report.reporterUser);
-            try {
-                reporterMember.send({
-                    content: `Your report for the user <@${report.reportedUser}> has been accepted and the user has been blacklisted from future collabs.`,
-                });
-            } catch (e) {
-                console.log(e);
-                const logChannel = guild.channels.cache.get(localConstants.logChannelID);
-                logChannel.send({
-                    content: `<@${report.reporterUser}> Your report for the user <@${report.reportedUser}> has been accepted and the user has been blacklisted from future collabs.`,
-                });
+            for (const snipe of snipes) {
+                contentString = contentString.concat('', `<@${snipe.userId}>`);
+                await localFunctions.removeCollabSnipe(collab.name, collection, snipe.userId);
             }
-
-            await message.edit({ embeds: [reportEmbed], components: [] });
-            await localFunctions.liquidateReport(report._id);
-            await int.editReply('The user has been blacklisted.');
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
-            mongoClientBlacklist.close();
         }
-    },
+
+        const leaveEmbed = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setDescription(`**\`\`\`ml\n📣 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${pickFull.name}\nID: ${pickFull.id}`)
+            .setImage(pickFull.imgURL)
+        logChannel.send({ content: `${contentString}\nUser <@${fullParticipation.discordId}> has been blacklisted from the collabs.\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Removed by:** <@${int.user.id}>`, embeds: [leaveEmbed] });
+
+        const auditEmbed = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An user has been blacklisted!**\n\n**Pick Name**: ${pickFull.name}\n**Pick ID**: ${pickFull.id}\n**Ex-Owner**: <@${fullParticipation.discordId}>\n**Removed by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
+        auditChannel.send({ content: '', embeds: [auditEmbed] });
+
+        let reportEmbed = new EmbedBuilder()
+            .setFooter({ text: "Endless Mirage | Report Accepted", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setTimestamp()
+            .setURL('https://endlessmirage.net/')
+            .setDescription(`**\`\`\`📣 Report Accepted\`\`\`**\n**Action taken:** Blacklist\n**Admin:** <@${int.user.id}>`)
+            .addFields(
+                {
+                    name: report.embed.data.fields[0].name,
+                    value: report.embed.data.fields[0].value
+                },
+                {
+                    name: report.embed.data.fields[1].name,
+                    value: report.embed.data.fields[1].value
+                }
+            )
+
+        const reporterMember = await guild.members.cache.find(member => member.id === report.reporterUser);
+        try {
+            reporterMember.send({
+                content: `Your report for the user <@${report.reportedUser}> has been accepted and the user has been blacklisted from future collabs.`,
+            });
+        } catch (e) {
+            console.log(e);
+            const logChannel = guild.channels.cache.get(localConstants.logChannelID);
+            logChannel.send({
+                content: `<@${report.reporterUser}> Your report for the user <@${report.reportedUser}> has been accepted and the user has been blacklisted from future collabs.`,
+            });
+        }
+
+        await message.edit({ embeds: [reportEmbed], components: [] });
+        await localFunctions.liquidateReport(report._id);
+        await int.editReply('The user has been blacklisted.');
+    }
 };

--- a/src/components/modals/change-osu-mode.js
+++ b/src/components/modals/change-osu-mode.js
@@ -1,17 +1,17 @@
 const { v2 } = require('osu-api-extended');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
     data: {
         name: 'change-osu-mode'
     },
-    async execute(int) {
+    async execute(int, client) {
         const userId = int.user.id;
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("OzenCollection");
+        const collabCollection = client.db.collection("Collabs");
         const currentDate = Math.floor(new Date().getTime() / 1000);
+
         try {
             let mode = int.fields.getTextInputValue('mode');
             mode = mode.toLowerCase();
@@ -105,9 +105,6 @@ module.exports = {
             userOsu.modsData = modsData;
             await localFunctions.verifyUserManual(int.user.id, userOsu, collection);
             await localFunctions.setUserLastUpdate(userId, currentDate, collection);
-        } finally {
-            mongoClient.close();
-            mongoClientCollabs.close();
         }
     },
 };

--- a/src/components/modals/change-texts.js
+++ b/src/components/modals/change-texts.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { editCache } = require('../buttons/change-texts');
@@ -9,44 +8,40 @@ module.exports = {
         name: "change-texts"
     },
     async execute(int, client) {
-        await int.deferReply({ephemeral: true});
+        await int.deferReply({ ephemeral: true });
         let editString = '';
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("OzenCollection");
+        const collabCollection = client.db.collection("Collabs");
         const collabName = editCache.get(int.user.id).collab;
         const guild = client.guilds.cache.get(localConstants.guildId);
         const userLogChannel = guild.channels.cache.get(localConstants.userActionsLogChannelID);
-        try {
-            const userCollab = await localFunctions.getUserCollab(int.user.id, collection, collabName);
-            let av_text = int.fields.getTextInputValue('av_text');
-            if (!av_text) {
-                av_text = userCollab.av_text;
-            } else {
-                editString = editString.concat(`\n Avatar text: ${av_text}`)
-            }
-            let ca_text = int.fields.getTextInputValue('ca_text');
-            if (!ca_text) {
-                ca_text = userCollab.ca_text;
-            } else {
-                editString = editString.concat(`\n Card text: ${ca_text}`)
-            }
-            let ca_quote = int.fields.getTextInputValue('ca_quote');
-            if (!ca_quote) {
-                ca_quote = userCollab.ca_quote;
-            } else {
-                editString = editString.concat(`\n Card quote: ${ca_quote}`)
-            }
-            await localFunctions.editParticipationFields(int.user.id, collabName, av_text, ca_text, ca_quote, collection);
-            await localFunctions.editCollabUserFields(int.user.id, collabName, av_text, ca_text, ca_quote, collabCollection);
-            const logEmbed = new EmbedBuilder()
-                    .setFooter({ text: 'Endless Mirage | User Action Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                    .setColor('#f26e6a')
-                    .setDescription(`**\`\`\`ml\n📣 New Text Field Changes\`\`\`**                                                                                                        **The fields of an user have been edited!**\n\n**Collab**: ${collabName}\n**Owner**: <@${int.user.id}>\n${editString}`);
-            userLogChannel.send({ content: '', embeds: [logEmbed] });
-            await int.editReply(`You've edited the following parameters:${editString}`);
-        } finally {
-            mongoClient.close();
-            mongoClientCollabs.close();
+
+        const userCollab = await localFunctions.getUserCollab(int.user.id, collection, collabName);
+        let av_text = int.fields.getTextInputValue('av_text');
+        if (!av_text) {
+            av_text = userCollab.av_text;
+        } else {
+            editString = editString.concat(`\n Avatar text: ${av_text}`)
         }
-    },
+        let ca_text = int.fields.getTextInputValue('ca_text');
+        if (!ca_text) {
+            ca_text = userCollab.ca_text;
+        } else {
+            editString = editString.concat(`\n Card text: ${ca_text}`)
+        }
+        let ca_quote = int.fields.getTextInputValue('ca_quote');
+        if (!ca_quote) {
+            ca_quote = userCollab.ca_quote;
+        } else {
+            editString = editString.concat(`\n Card quote: ${ca_quote}`)
+        }
+        await localFunctions.editParticipationFields(int.user.id, collabName, av_text, ca_text, ca_quote, collection);
+        await localFunctions.editCollabUserFields(int.user.id, collabName, av_text, ca_text, ca_quote, collabCollection);
+        const logEmbed = new EmbedBuilder()
+                .setFooter({ text: 'Endless Mirage | User Action Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+                .setColor('#f26e6a')
+                .setDescription(`**\`\`\`ml\n📣 New Text Field Changes\`\`\`**                                                                                                        **The fields of an user have been edited!**\n\n**Collab**: ${collabName}\n**Owner**: <@${int.user.id}>\n${editString}`);
+        userLogChannel.send({ content: '', embeds: [logEmbed] });
+        await int.editReply(`You've edited the following parameters:${editString}`);
+    }
 };

--- a/src/components/modals/check-pick.js
+++ b/src/components/modals/check-pick.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
@@ -13,7 +12,7 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("Collabs");
         let initializedMap;
         if (profileMenuCache.size > 0) {
             if (typeof profileMenuCache.get(int.user.id) !== "undefined") {
@@ -148,8 +147,6 @@ module.exports = {
 
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
         }
     },
     claimCacheModal: claimCacheModal,

--- a/src/components/modals/delete-collab.js
+++ b/src/components/modals/delete-collab.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { deleteCache } = require('../buttons/delete-collab');
 
@@ -8,23 +7,17 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply();
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
         
-        try {
-            let name = int.fields.getTextInputValue('name');
-            if (deleteCache.get(int.user.id).collab.host === int.user.id && deleteCache.get(int.user.id).collab.name === name) {
-                await localFunctions.liquidateCollab(deleteCache.get(int.user.id).collab.name, collection);
-                await localFunctions.liquidateCollabFromUsers(deleteCache.get(int.user.id).collab.name, userCollection);
-                await int.editReply('The collab has been deleted.');
-                deleteCache.delete(int.user.id);
-            } else {
-                await int.editReply('Verification for deletion failed.');
-                return;
-            }
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
+        let name = int.fields.getTextInputValue('name');
+        if (deleteCache.get(int.user.id).collab.host === int.user.id && deleteCache.get(int.user.id).collab.name === name) {
+            await localFunctions.liquidateCollab(deleteCache.get(int.user.id).collab.name, collection);
+            await localFunctions.liquidateCollabFromUsers(deleteCache.get(int.user.id).collab.name, userCollection);
+            await int.editReply('The collab has been deleted.');
+            deleteCache.delete(int.user.id);
+        } else {
+            await int.editReply('Verification for deletion failed.');
         }
-    },
+    }
 };

--- a/src/components/modals/deliver-collab.js
+++ b/src/components/modals/deliver-collab.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { collabCache } = require('../buttons/admin-collab');
 const { adminCache }= require('../../commands/collabs/collabs');
@@ -10,7 +9,7 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("Collabs");
         let initializedMap;
         if (collabCache.size > 0) {
             if (typeof collabCache.get(int.user.id) !== "undefined") {
@@ -22,59 +21,57 @@ module.exports = {
                 initializedMap = adminCache;
             }
         }
-        try {
-            const collab = initializedMap.get(int.user.id).collab;
-            const fullCollab = await localFunctions.getCollab(collab, collection);
-            const logChannel = fullCollab.logChannel;
-            let ping = "";
-            switch (fullCollab.restriction) {
-                case "none":
-                    break;
-                case "megacollab":
-                    ping = "<@&854444817316577340>"
-                    break;
-                default:
-                    if (typeof fullCollab.role !== "undefined") {
-                        ping = `<@&${fullCollab.role}>`
-                    }
-            }           
-            const bucketURL = `https://storage.googleapis.com/${int.fields.getTextInputValue('bucket')}/`
-            await localFunctions.setCollabBucket(collab, bucketURL, collection);
-            await localFunctions.setCollabStatus(collab, 'delivered', collection);
-            let embeds = [];
-            const dashboardEmbed = new EmbedBuilder()
-                .setColor(fullCollab.color)
-                .setURL('https://endlessmirage.net/')
-
-            dashboardEmbed.setDescription(`**\`\`\`\n🏐 ${fullCollab.name} has been delivered open!\`\`\`**`);
-            dashboardEmbed.setFooter({ text: 'Endless Mirage | Collabs Dashboard', iconURL: 'attachment://footer.png' })
-            embeds.push(dashboardEmbed);
-            if (fullCollab.designs.length !== 0) {
-                for (const design in fullCollab.designs) {
-                    let embed = new EmbedBuilder()
-                        .setURL('https://endlessmirage.net/')
-                        .setImage(fullCollab.designs[design]);
-
-                    embeds.push(embed);
+        
+        const collab = initializedMap.get(int.user.id).collab;
+        const fullCollab = await localFunctions.getCollab(collab, collection);
+        const logChannel = fullCollab.logChannel;
+        let ping = "";
+        switch (fullCollab.restriction) {
+            case "none":
+                break;
+            case "megacollab":
+                ping = "<@&854444817316577340>"
+                break;
+            default:
+                if (typeof fullCollab.role !== "undefined") {
+                    ping = `<@&${fullCollab.role}>`
                 }
-            }
-            const attachment = new AttachmentBuilder(fullCollab.thumbnail, {
-                name: "thumbnail.png"
-            });
+        }           
+        const bucketURL = `https://storage.googleapis.com/${int.fields.getTextInputValue('bucket')}/`
+        await localFunctions.setCollabBucket(collab, bucketURL, collection);
+        await localFunctions.setCollabStatus(collab, 'delivered', collection);
+        let embeds = [];
+        const dashboardEmbed = new EmbedBuilder()
+            .setColor(fullCollab.color)
+            .setURL('https://endlessmirage.net/')
 
-            await logChannel.send({
-                content: ping,
-                files: [attachment,
-                    {
-                        attachment: `./assets/coloredLogos/logo-${fullCollab.color}.png`,
-                        name: 'footer.png'
-                    }
-                ],
-                embeds: embeds,
-            })
-            int.editReply('The collab has been delivered!');
-        } finally {
-            mongoClient.close();
+        dashboardEmbed.setDescription(`**\`\`\`\n🏐 ${fullCollab.name} has been delivered open!\`\`\`**`);
+        dashboardEmbed.setFooter({ text: 'Endless Mirage | Collabs Dashboard', iconURL: 'attachment://footer.png' })
+        embeds.push(dashboardEmbed);
+        if (fullCollab.designs.length !== 0) {
+            for (const design in fullCollab.designs) {
+                let embed = new EmbedBuilder()
+                    .setURL('https://endlessmirage.net/')
+                    .setImage(fullCollab.designs[design]);
+
+                embeds.push(embed);
+            }
         }
-    },
+        const attachment = new AttachmentBuilder(fullCollab.thumbnail, {
+            name: "thumbnail.png"
+        });
+
+        await logChannel.send({
+            content: ping,
+            files: [attachment,
+                {
+                    attachment: `./assets/coloredLogos/logo-${fullCollab.color}.png`,
+                    name: 'footer.png'
+                }
+            ],
+            embeds: embeds,
+        });
+
+        await int.editReply('The collab has been delivered!');
+    }
 };

--- a/src/components/modals/edit-fields-report.js
+++ b/src/components/modals/edit-fields-report.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { reportCache } = require('../buttons/report-accept');
@@ -12,129 +11,125 @@ module.exports = {
         await int.deferReply({ ephemeral: true });
         let editString = '';
         let textEdits = false;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("OzenCollection");
+        const collabCollection = client.db.collection("Collabs");
         const report = reportCache.get(int.user.id).report;
         const message = reportCache.get(int.user.id).message;
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         const auditChannel = guild.channels.cache.get(localConstants.auditLogChannelID);
-        try {
-            const collab = await localFunctions.getCollab(report.collab, collabCollection);
-            const collabName = collab.name;
-            const participation = collab.participants.find((e) => e.id === report.pickId);
-            const userCollab = await localFunctions.getUserCollab(participation.discordId, collection, collabName);
-            let av_text = int.fields.getTextInputValue('av_text');
-            if (!av_text) {
-                av_text = userCollab.av_text;
-            } else {
-                editString = editString.concat(`\n **Avatar text**: ${av_text}`);
-                textEdits = true;
-            }
-            let ca_text = int.fields.getTextInputValue('ca_text');
-            if (!ca_text) {
-                ca_text = userCollab.ca_text;
-            } else {
-                editString = editString.concat(`\n **Card text**: ${ca_text}`);
-                textEdits = true;
-            }
-            let ca_quote = int.fields.getTextInputValue('ca_quote');
-            if (!ca_quote) {
-                ca_quote = userCollab.ca_quote;
-            } else {
-                editString = editString.concat(`\n **Card quote**: ${ca_quote}`);
-                textEdits = true;
-            }
 
-            if (textEdits) {
-                await localFunctions.editParticipationFields(participation.discordId, collabName, av_text, ca_text, ca_quote, collection);
-                await localFunctions.editCollabUserFields(participation.discordId, collabName, av_text, ca_text, ca_quote, collabCollection);
+        const collab = await localFunctions.getCollab(report.collab, collabCollection);
+        const collabName = collab.name;
+        const participation = collab.participants.find((e) => e.id === report.pickId);
+        const userCollab = await localFunctions.getUserCollab(participation.discordId, collection, collabName);
+        let av_text = int.fields.getTextInputValue('av_text');
+        if (!av_text) {
+            av_text = userCollab.av_text;
+        } else {
+            editString = editString.concat(`\n **Avatar text**: ${av_text}`);
+            textEdits = true;
+        }
+        let ca_text = int.fields.getTextInputValue('ca_text');
+        if (!ca_text) {
+            ca_text = userCollab.ca_text;
+        } else {
+            editString = editString.concat(`\n **Card text**: ${ca_text}`);
+            textEdits = true;
+        }
+        let ca_quote = int.fields.getTextInputValue('ca_quote');
+        if (!ca_quote) {
+            ca_quote = userCollab.ca_quote;
+        } else {
+            editString = editString.concat(`\n **Card quote**: ${ca_quote}`);
+            textEdits = true;
+        }
 
-                const editEmbed = new EmbedBuilder()
-                    .setFooter({ text: 'Endless Mirage | Admin Action', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                    .setColor('#f26e6a')
-                    .setDescription(`**\`\`\`ml\n📣 New Input Edit By Admins...\`\`\`**                                                                                                        **${collab.name}**\n${editString}`)
-                logChannel.send({ content: `<@${participation.discordId}> Your input has been edited!\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Edited by:** <@${int.user.id}>`, embeds: [editEmbed] });
+        if (textEdits) {
+            await localFunctions.editParticipationFields(participation.discordId, collabName, av_text, ca_text, ca_quote, collection);
+            await localFunctions.editCollabUserFields(participation.discordId, collabName, av_text, ca_text, ca_quote, collabCollection);
 
-                const auditEmbed = new EmbedBuilder()
-                    .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                    .setColor('#f26e6a')
-                    .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **The fields of an user have been edited!**\n\n**Pick Name**: ${participation.name}\n**Pick ID**: ${participation.id}\n**Owner**: <@${participation.discordId}>\n**Edited by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n${editString}`);
-                auditChannel.send({ content: '', embeds: [auditEmbed] });
-            }
-
-            let reportEmbed = new EmbedBuilder()
-                .setFooter({ text: "Endless Mirage | Report Accepted", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            const editEmbed = new EmbedBuilder()
+                .setFooter({ text: 'Endless Mirage | Admin Action', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
                 .setColor('#f26e6a')
-                .setTimestamp()
-                .setURL('https://endlessmirage.net/')
-                .setDescription(`**\`\`\`📣 Report Accepted\`\`\`**\n**Action taken:** Field edits\n**Admin:** <@${int.user.id}>`)
-                .addFields(
-                    {
-                        name: report.embed.data.fields[0].name,
-                        value: report.embed.data.fields[0].value
-                    },
-                    {
-                        name: report.embed.data.fields[1].name,
-                        value: report.embed.data.fields[1].value
-                    }
-                )
+                .setDescription(`**\`\`\`ml\n📣 New Input Edit By Admins...\`\`\`**                                                                                                        **${collab.name}**\n${editString}`)
+            logChannel.send({ content: `<@${participation.discordId}> Your input has been edited!\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Edited by:** <@${int.user.id}>`, embeds: [editEmbed] });
 
-            await message.edit({ embeds: [reportEmbed], components: [] });
-            await localFunctions.liquidateReport(report._id);
-            const reporterMember = await guild.members.cache.find(member => member.id === report.reporterUser);
-            try {
-                reporterMember.send({
-                    content: `Your report for the user <@${report.reportedUser}> has been accepted and the fields of the user have been edited.`,
-                });
-            } catch (e) {
-                console.log(e);
-                const logChannel = guild.channels.cache.get(localConstants.logChannelID);
-                logChannel.send({
-                    content: `<@${report.reporterUser}> Your report for the user <@${report.reportedUser}> has been accepted and the fields of the user have been edited.`,
-                });
-            }
-
-            let newImg = int.fields.getTextInputValue('img');
-            if (!newImg) return int.editReply('The fields have been edited.');
-            if (!localFunctions.isPNGURL(newImg)) {
-                if (textEdits) {
-                    return int.editReply('The fields have been edited, but the image provided is not a PNG! Provide a PNG image to edit this field.');
-                } else {
-                    return int.editReply('The image provided is not a PNG! Provide a PNG image to edit this field.');
-                }
-            }
-            let oldImg = participation.imgURL;
-            await localFunctions.editPickImage(participation.id, participation.discordId, collab.name, collabCollection, collection, newImg);
-            let imageSwapEmbed = new EmbedBuilder()
-                .setFooter({ text: "Endless Mirage | Admin Action", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setTimestamp()
-                .setImage(newImg)
-                .setURL('https://endlessmirage.net/')
-                .setDescription(`**\`\`\`📣 New Input Edit By Admins...\`\`\`**`)
-
-            let oldImageEmbed = new EmbedBuilder()
-                .setURL('https://endlessmirage.net/')
-                .setImage(oldImg)
-
-            logChannel.send({ content: `<@${participation.discordId}> Your image has been edited!\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Edited by:** <@${int.user.id}>`, embeds: [imageSwapEmbed, oldImageEmbed] });
-            const auditEmbedImg1 = new EmbedBuilder()
+            const auditEmbed = new EmbedBuilder()
                 .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
                 .setColor('#f26e6a')
-                .setImage(newImg)
-                .setURL('https://endlessmirage.net/')
-                .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An image has been edited!**\n\n**Pick Name**: ${participation.name}\n**Pick ID**: ${participation.id}\n**Owner**: <@${participation.discordId}>\n**Edited by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
-            let auditEmbedImg2 = new EmbedBuilder()
+                .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **The fields of an user have been edited!**\n\n**Pick Name**: ${participation.name}\n**Pick ID**: ${participation.id}\n**Owner**: <@${participation.discordId}>\n**Edited by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n${editString}`);
+            auditChannel.send({ content: '', embeds: [auditEmbed] });
+        }
+
+        let reportEmbed = new EmbedBuilder()
+            .setFooter({ text: "Endless Mirage | Report Accepted", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setTimestamp()
+            .setURL('https://endlessmirage.net/')
+            .setDescription(`**\`\`\`📣 Report Accepted\`\`\`**\n**Action taken:** Field edits\n**Admin:** <@${int.user.id}>`)
+            .addFields(
+                {
+                    name: report.embed.data.fields[0].name,
+                    value: report.embed.data.fields[0].value
+                },
+                {
+                    name: report.embed.data.fields[1].name,
+                    value: report.embed.data.fields[1].value
+                }
+            )
+
+        await message.edit({ embeds: [reportEmbed], components: [] });
+        await localFunctions.liquidateReport(report._id);
+        const reporterMember = await guild.members.cache.find(member => member.id === report.reporterUser);
+        try {
+            reporterMember.send({
+                content: `Your report for the user <@${report.reportedUser}> has been accepted and the fields of the user have been edited.`,
+            });
+        } catch (e) {
+            console.log(e);
+            const logChannel = guild.channels.cache.get(localConstants.logChannelID);
+            logChannel.send({
+                content: `<@${report.reporterUser}> Your report for the user <@${report.reportedUser}> has been accepted and the fields of the user have been edited.`,
+            });
+        }
+
+        let newImg = int.fields.getTextInputValue('img');
+        if (!newImg) return int.editReply('The fields have been edited.');
+        if (!localFunctions.isPNGURL(newImg)) {
+            if (textEdits) {
+                return int.editReply('The fields have been edited, but the image provided is not a PNG! Provide a PNG image to edit this field.');
+            } else {
+                return int.editReply('The image provided is not a PNG! Provide a PNG image to edit this field.');
+            }
+        }
+        let oldImg = participation.imgURL;
+        await localFunctions.editPickImage(participation.id, participation.discordId, collab.name, collabCollection, collection, newImg);
+        let imageSwapEmbed = new EmbedBuilder()
+            .setFooter({ text: "Endless Mirage | Admin Action", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setTimestamp()
+            .setImage(newImg)
+            .setURL('https://endlessmirage.net/')
+            .setDescription(`**\`\`\`📣 New Input Edit By Admins...\`\`\`**`)
+
+        let oldImageEmbed = new EmbedBuilder()
             .setURL('https://endlessmirage.net/')
             .setImage(oldImg)
 
-            auditChannel.send({ content: '', embeds: [auditEmbedImg1, auditEmbedImg2] });
+        logChannel.send({ content: `<@${participation.discordId}> Your image has been edited!\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Edited by:** <@${int.user.id}>`, embeds: [imageSwapEmbed, oldImageEmbed] });
+        const auditEmbedImg1 = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setImage(newImg)
+            .setURL('https://endlessmirage.net/')
+            .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An image has been edited!**\n\n**Pick Name**: ${participation.name}\n**Pick ID**: ${participation.id}\n**Owner**: <@${participation.discordId}>\n**Edited by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
+        let auditEmbedImg2 = new EmbedBuilder()
+        .setURL('https://endlessmirage.net/')
+        .setImage(oldImg)
 
-            await int.editReply('The image has been edited.');
-        } finally {
-            mongoClient.close();
-            mongoClientCollabs.close();
-        }
-    },
+        auditChannel.send({ content: '', embeds: [auditEmbedImg1, auditEmbedImg2] });
+
+        await int.editReply('The image has been edited.');
+    }
 };

--- a/src/components/modals/edit-fields-user-collab-admin.js
+++ b/src/components/modals/edit-fields-user-collab-admin.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { collabCache } = require('./manage-pick-collab');
@@ -24,95 +23,91 @@ module.exports = {
         }
         let editString = '';
         let textEdits = false;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("OzenCollection");
+        const collabCollection = client.db.collection("Collabs");
         const collab = initializedMap.get(int.user.id).collab;
         const collabName = collab.name;
         const guild = client.guilds.cache.get(localConstants.guildId);
         const participation = initializedMap.get(int.user.id).participation;
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         const auditChannel = guild.channels.cache.get(localConstants.auditLogChannelID);
-        try {
-            const userCollab = await localFunctions.getUserCollab(participation.discordId, collection, collabName);
-            let av_text = int.fields.getTextInputValue('av_text');
-            if (!av_text) {
-                av_text = userCollab.av_text;
-            } else {
-                editString = editString.concat(`\n **Avatar text**: ${av_text}`);
-                textEdits = true;
-            }
-            let ca_text = int.fields.getTextInputValue('ca_text');
-            if (!ca_text) {
-                ca_text = userCollab.ca_text;
-            } else {
-                editString = editString.concat(`\n **Card text**: ${ca_text}`);
-                textEdits = true;
-            }
-            let ca_quote = int.fields.getTextInputValue('ca_quote');
-            if (!ca_quote) {
-                ca_quote = userCollab.ca_quote;
-            } else {
-                editString = editString.concat(`\n **Card quote**: ${ca_quote}`);
-                textEdits = true;
-            }
+        
+        const userCollab = await localFunctions.getUserCollab(participation.discordId, collection, collabName);
+        let av_text = int.fields.getTextInputValue('av_text');
+        if (!av_text) {
+            av_text = userCollab.av_text;
+        } else {
+            editString = editString.concat(`\n **Avatar text**: ${av_text}`);
+            textEdits = true;
+        }
+        let ca_text = int.fields.getTextInputValue('ca_text');
+        if (!ca_text) {
+            ca_text = userCollab.ca_text;
+        } else {
+            editString = editString.concat(`\n **Card text**: ${ca_text}`);
+            textEdits = true;
+        }
+        let ca_quote = int.fields.getTextInputValue('ca_quote');
+        if (!ca_quote) {
+            ca_quote = userCollab.ca_quote;
+        } else {
+            editString = editString.concat(`\n **Card quote**: ${ca_quote}`);
+            textEdits = true;
+        }
 
-            if (textEdits) {
-                await localFunctions.editParticipationFields(participation.discordId, collabName, av_text, ca_text, ca_quote, collection);
-                await localFunctions.editCollabUserFields(participation.discordId, collabName, av_text, ca_text, ca_quote, collabCollection);
+        if (textEdits) {
+            await localFunctions.editParticipationFields(participation.discordId, collabName, av_text, ca_text, ca_quote, collection);
+            await localFunctions.editCollabUserFields(participation.discordId, collabName, av_text, ca_text, ca_quote, collabCollection);
 
-                const editEmbed = new EmbedBuilder()
-                    .setFooter({ text: 'Endless Mirage | Admin Action', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                    .setColor('#f26e6a')
-                    .setDescription(`**\`\`\`ml\n📣 New Input Edit By Admins...\`\`\`**                                                                                                        **${collab.name}**\n${editString}`)
-                logChannel.send({ content: `<@${participation.discordId}> Your input has been edited!\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Edited by:** <@${int.user.id}>`, embeds: [editEmbed] });
-
-                const auditEmbed = new EmbedBuilder()
-                    .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                    .setColor('#f26e6a')
-                    .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **The fields of an user have been edited!**\n\n**Pick Name**: ${participation.name}\n**Pick ID**: ${participation.id}\n**Owner**: <@${participation.discordId}>\n**Edited by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n${editString}`);
-                auditChannel.send({ content: '', embeds: [auditEmbed] });
-            }
-
-            let newImg = int.fields.getTextInputValue('img');
-            if (!newImg) return int.editReply('The fields have been edited.');
-            if (!localFunctions.isPNGURL(newImg)) {
-                if (textEdits) {
-                    return int.editReply('The fields have been edited, but the image provided is not a PNG! Provide a PNG image to edit this field.');
-                } else {
-                    return int.editReply('The image provided is not a PNG! Provide a PNG image to edit this field.');
-                }
-            }
-            let oldImg = participation.imgURL;
-            await localFunctions.editPickImage(participation.id, participation.discordId, collab.name, collabCollection, collection, newImg);
-            let imageSwapEmbed = new EmbedBuilder()
-                .setFooter({ text: "Endless Mirage | Admin Action", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            const editEmbed = new EmbedBuilder()
+                .setFooter({ text: 'Endless Mirage | Admin Action', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
                 .setColor('#f26e6a')
-                .setTimestamp()
-                .setImage(newImg)
-                .setURL('https://endlessmirage.net/')
-                .setDescription(`**\`\`\`📣 New Input Edit By Admins...\`\`\`**`)
+                .setDescription(`**\`\`\`ml\n📣 New Input Edit By Admins...\`\`\`**                                                                                                        **${collab.name}**\n${editString}`)
+            logChannel.send({ content: `<@${participation.discordId}> Your input has been edited!\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Edited by:** <@${int.user.id}>`, embeds: [editEmbed] });
 
-            let oldImageEmbed = new EmbedBuilder()
-                .setURL('https://endlessmirage.net/')
-                .setImage(oldImg)
-
-            logChannel.send({ content: `<@${participation.discordId}> Your image has been edited!\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Edited by:** <@${int.user.id}>`, embeds: [imageSwapEmbed, oldImageEmbed] });
-            const auditEmbedImg1 = new EmbedBuilder()
+            const auditEmbed = new EmbedBuilder()
                 .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
                 .setColor('#f26e6a')
-                .setImage(newImg)
-                .setURL('https://endlessmirage.net/')
-                .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An image has been edited!**\n\n**Pick Name**: ${participation.name}\n**Pick ID**: ${participation.id}\n**Owner**: <@${participation.discordId}>\n**Edited by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
-            let auditEmbedImg2 = new EmbedBuilder()
+                .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **The fields of an user have been edited!**\n\n**Pick Name**: ${participation.name}\n**Pick ID**: ${participation.id}\n**Owner**: <@${participation.discordId}>\n**Edited by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n${editString}`);
+            auditChannel.send({ content: '', embeds: [auditEmbed] });
+        }
+
+        let newImg = int.fields.getTextInputValue('img');
+        if (!newImg) return int.editReply('The fields have been edited.');
+        if (!localFunctions.isPNGURL(newImg)) {
+            if (textEdits) {
+                return int.editReply('The fields have been edited, but the image provided is not a PNG! Provide a PNG image to edit this field.');
+            } else {
+                return int.editReply('The image provided is not a PNG! Provide a PNG image to edit this field.');
+            }
+        }
+        let oldImg = participation.imgURL;
+        await localFunctions.editPickImage(participation.id, participation.discordId, collab.name, collabCollection, collection, newImg);
+        let imageSwapEmbed = new EmbedBuilder()
+            .setFooter({ text: "Endless Mirage | Admin Action", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setTimestamp()
+            .setImage(newImg)
+            .setURL('https://endlessmirage.net/')
+            .setDescription(`**\`\`\`📣 New Input Edit By Admins...\`\`\`**`)
+
+        let oldImageEmbed = new EmbedBuilder()
             .setURL('https://endlessmirage.net/')
             .setImage(oldImg)
 
-            auditChannel.send({ content: '', embeds: [auditEmbedImg1, auditEmbedImg2] });
+        logChannel.send({ content: `<@${participation.discordId}> Your image has been edited!\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Edited by:** <@${int.user.id}>`, embeds: [imageSwapEmbed, oldImageEmbed] });
+        const auditEmbedImg1 = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setImage(newImg)
+            .setURL('https://endlessmirage.net/')
+            .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An image has been edited!**\n\n**Pick Name**: ${participation.name}\n**Pick ID**: ${participation.id}\n**Owner**: <@${participation.discordId}>\n**Edited by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
+        let auditEmbedImg2 = new EmbedBuilder()
+        .setURL('https://endlessmirage.net/')
+        .setImage(oldImg)
 
-            await int.editReply('The image has been edited.');
-        } finally {
-            mongoClient.close();
-            mongoClientCollabs.close();
-        }
-    },
+        auditChannel.send({ content: '', embeds: [auditEmbedImg1, auditEmbedImg2] });
+
+        await int.editReply('The image has been edited.');
+    }
 };

--- a/src/components/modals/edit-pick-collab-admin.js
+++ b/src/components/modals/edit-pick-collab-admin.js
@@ -2,7 +2,6 @@ const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { userCheckCache } = require('../../commands/collabs/collabs');
 const { userCheckCacheModal } = require('./check-pick');
-const { connectToMongoDB } = require('../../mongo');
 const { EmbedBuilder } = require('discord.js');
 
 module.exports = {
@@ -31,33 +30,30 @@ module.exports = {
       contentString = `<@${user}>`
     }
     const collab = initializedMap.get(int.user.id).collab.name;
-    const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-    const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
-    try {
-      await localFunctions.editPickName(pick.id, user, collab, collabCollection, userCollection, int.fields.getTextInputValue("ch_name"));
-      const logChannel = guild.channels.cache.get(localConstants.logChannelID);
-      const auditChannel = guild.channels.cache.get(localConstants.auditLogChannelID);
-      let charEmbed = new EmbedBuilder()
-        .setFooter({ text: "Endless Mirage | Character Name Edit", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-        .setColor('#f26e6a')
-        .setTimestamp()
-        .setDescription(`**\`\`\`🏐 Admin character edit!\`\`\`**                                                                                                        \n**Old Name**: ${pick.name}\n**New name:** ${int.fields.getTextInputValue("ch_name")}`)
-        .addFields(
-          {
-            name: "‎",
-            value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:19:1195441100350034063><:21:1195441102585606144><:23:1195440971886903356><:25:1195441155664527410><:27:1195440974978093147>",
-          }
-        )
-      await logChannel.send({ content: `${contentString} Your pick has been edited.`, embeds: [charEmbed] });
-      const auditEmbed = new EmbedBuilder()
-        .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-        .setColor('#f26e6a')
-        .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **A pick's name has been changed**\n\n**Pick ID**: ${pick.id}\n**Old Name**: ${pick.name}\n**New Name**: ${int.fields.getTextInputValue("ch_name")}`);
-      auditChannel.send({ content: '', embeds: [auditEmbed] });
-      await int.editReply({ content: 'The name of the pick has been changed.', ephemeral: true });
-    } finally {
-      mongoClientCollabs.close();
-      mongoClientUsers.close();
-    }
-  },
+
+    const userCollection = client.db.collection("OzenCollection");
+    const collabCollection = client.db.collection("Collabs");
+
+    await localFunctions.editPickName(pick.id, user, collab, collabCollection, userCollection, int.fields.getTextInputValue("ch_name"));
+    const logChannel = guild.channels.cache.get(localConstants.logChannelID);
+    const auditChannel = guild.channels.cache.get(localConstants.auditLogChannelID);
+    let charEmbed = new EmbedBuilder()
+      .setFooter({ text: "Endless Mirage | Character Name Edit", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+      .setColor('#f26e6a')
+      .setTimestamp()
+      .setDescription(`**\`\`\`🏐 Admin character edit!\`\`\`**                                                                                                        \n**Old Name**: ${pick.name}\n**New name:** ${int.fields.getTextInputValue("ch_name")}`)
+      .addFields(
+        {
+          name: "‎",
+          value: "<:01:1195440946989502614><:02:1195440949157970090><:03:1195440950311387286><:04:1195440951498391732><:05:1195440953616502814><:06:1195440954895765647><:07:1195440956057604176><:08:1195440957735325707><:09:1195440958850998302><:10:1195441088501133472><:11:1195441090677968936><:12:1195440961275306025><:13:1195441092036919296><:14:1195441092947103847><:15:1195441095811797123><:16:1195440964907573328><:17:1195441098768789586><:19:1195441100350034063><:21:1195441102585606144><:23:1195440971886903356><:25:1195441155664527410><:27:1195440974978093147>",
+        }
+      )
+    await logChannel.send({ content: `${contentString} Your pick has been edited.`, embeds: [charEmbed] });
+    const auditEmbed = new EmbedBuilder()
+      .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+      .setColor('#f26e6a')
+      .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **A pick's name has been changed**\n\n**Pick ID**: ${pick.id}\n**Old Name**: ${pick.name}\n**New Name**: ${int.fields.getTextInputValue("ch_name")}`);
+    auditChannel.send({ content: '', embeds: [auditEmbed] });
+    await int.editReply({ content: 'The name of the pick has been changed.', ephemeral: true });
+  }
 };

--- a/src/components/modals/join-collab-random.js
+++ b/src/components/modals/join-collab-random.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
@@ -13,9 +12,9 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         buttonCache.delete(int.user.id);
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: collabsCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+        const collabsCollection = client.db.collection("Collabs");
         const userId = int.user.id;
         const guild = client.guilds.cache.get(localConstants.guildId);
         const guildMember = guild.members.cache.get(userId);
@@ -279,9 +278,6 @@ module.exports = {
             console.log(e);
             await int.editReply('Your pick has been locked but there has been an error while joining the collab. Please ping the owner in the support channel!');
         } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
-            mongoClientCollabs.close();
             joinCache.delete(userId);
         }
     },

--- a/src/components/modals/join-collab.js
+++ b/src/components/modals/join-collab.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
@@ -13,9 +12,9 @@ module.exports = {
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
         buttonCache.delete(int.user.id);
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: collabsCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+        const collabsCollection = client.db.collection("Collabs");
         const userId = int.user.id;
         const guild = client.guilds.cache.get(localConstants.guildId);
         const guildMember = guild.members.cache.get(userId);
@@ -280,9 +279,6 @@ module.exports = {
             console.log(e);
             await int.editReply('Your pick has been locked but there has been an error while joining the collab. Please ping the owner in the support channel!');
         } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
-            mongoClientCollabs.close();
             joinCache.delete(userId);
         }
     },

--- a/src/components/modals/leave-collab.js
+++ b/src/components/modals/leave-collab.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
@@ -10,9 +9,9 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB('Special');
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+        const collectionSpecial = client.db.collection("Special");
         const userId = int.user.id;
         const guild = await client.guilds.cache.get(localConstants.guildId);
         const guildMember = await guild.members.fetch(userId);
@@ -88,10 +87,6 @@ module.exports = {
             }
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
-            mongoClientSpecial.close();
         }
-    },
+    }
 };

--- a/src/components/modals/perk-edit.js
+++ b/src/components/modals/perk-edit.js
@@ -1,5 +1,4 @@
 const { perkCache } = require('../../components/buttons/perk-edit');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -8,7 +7,7 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("Collabs");
         const cache = perkCache.get(int.user.id);
         const perk = cache.perk
         try {
@@ -34,8 +33,7 @@ module.exports = {
             int.editReply('Your entry has been edited.');
             
         } finally {
-            mongoClient.close();
             perkCache.delete(int.user.id);
         }
-    },
+    }
 };

--- a/src/components/modals/perk-modal.js
+++ b/src/components/modals/perk-modal.js
@@ -1,5 +1,4 @@
 const { perkCache } = require('../../components/selectMenus/use-perks');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -8,7 +7,7 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
+        const collection = client.db.collection("Collabs");
         const cache = perkCache.get(int.user.id);
         const perk = cache.perk
         try {
@@ -33,7 +32,6 @@ module.exports = {
             int.editReply('Your entry has been submitted! Use ``/collabs perks`` to manage all of your entries.');
             
         } finally {
-            mongoClient.close();
             perkCache.delete(int.user.id);
         }
     },

--- a/src/components/modals/perk-prune.js
+++ b/src/components/modals/perk-prune.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { managePerkCache } = require('../selectMenus/manage-perks');
 
@@ -7,23 +6,19 @@ module.exports = {
         name: "perk-prune"
     },
     async execute(int, client) {
-        await int.deferReply({ephemeral: true});
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        try {
-            let name = int.fields.getTextInputValue('name');
-            const collabName = managePerkCache.get(int.user.id).collabName;
-            const perkName = managePerkCache.get(int.user.id).perkName;
-            if (name === perkName) {
-                await localFunctions.liquidatePerkEntry(int.user.id, collabName, perkName, collection);
-
-                await int.editReply('Your entry has been removed.');
-                managePerkCache.delete(int.user.id);
-            } else {
-                await int.editReply('Verification for removal failed.');
-                return;
-            }
-        } finally {
-            mongoClient.close();
+        await int.deferReply({ ephemeral: true });
+        const collection = client.db.collection("Collabs");
+        
+        let name = int.fields.getTextInputValue('name');
+        const collabName = managePerkCache.get(int.user.id).collabName;
+        const perkName = managePerkCache.get(int.user.id).perkName;
+        if (name === perkName) {
+            await localFunctions.liquidatePerkEntry(int.user.id, collabName, perkName, collection);
+            await int.editReply('Your entry has been removed.');
+            managePerkCache.delete(int.user.id);
+        } else {
+            await int.editReply('Verification for removal failed.');
+            return;
         }
-    },
+    }
 };

--- a/src/components/modals/remove-user-collab-admin.js
+++ b/src/components/modals/remove-user-collab-admin.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { collabCache } = require('./manage-pick-collab');
@@ -21,58 +20,53 @@ module.exports = {
                 initializedMap = userCheckCache;
             }
         }
-        await int.deferReply({ephemeral: true});
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
+        await int.deferReply({ ephemeral: true });
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         const auditChannel = guild.channels.cache.get(localConstants.auditLogChannelID);
 
-        try {
-            const collab = initializedMap.get(int.user.id).collab;
-            const pickFull = initializedMap.get(int.user.id).pick;
-            let participants = collab.participants;
-            const id = pickFull.id;
-            const fullParticipation = participants.find((e) => e.id === id);
+        const collab = initializedMap.get(int.user.id).collab;
+        const pickFull = initializedMap.get(int.user.id).pick;
+        let participants = collab.participants;
+        const id = pickFull.id;
+        const fullParticipation = participants.find((e) => e.id === id);
 
-            let userCollabs = await localFunctions.getUserCollabs(fullParticipation.discordId, userCollection);
-            await localFunctions.unsetCollabParticipation(collab.name, collection, id);
-            userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
-            await localFunctions.setUserCollabs(fullParticipation.discordId, userCollabs, userCollection);
-            await localFunctions.removeCollabParticipant(collab.name, collection, fullParticipation.discordId);
-            await localFunctions.unsetParticipationOnSheet(collab, pickFull);
+        let userCollabs = await localFunctions.getUserCollabs(fullParticipation.discordId, userCollection);
+        await localFunctions.unsetCollabParticipation(collab.name, collection, id);
+        userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
+        await localFunctions.setUserCollabs(fullParticipation.discordId, userCollabs, userCollection);
+        await localFunctions.removeCollabParticipant(collab.name, collection, fullParticipation.discordId);
+        await localFunctions.unsetParticipationOnSheet(collab, pickFull);
 
-            const pendingMember = await guild.members.fetch(fullParticipation.discordId);
-            await pendingMember.roles.remove(collab.roleId);
+        const pendingMember = await guild.members.fetch(fullParticipation.discordId);
+        await pendingMember.roles.remove(collab.roleId);
 
-            let contentString = "";
-            const snipes = await localFunctions.getCollabSnipes(collab.name, collection, id);
-            if (typeof snipes !== "undefined") {
-                if (typeof snipes.find(p => p.pick === id) !== "undefined") {
-                    contentString = "Snipers! ";
-                }
-                for (const snipe of snipes) {
-                    contentString = contentString.concat('', `<@${snipe.userId}>`);
-                    await localFunctions.removeCollabSnipe(collab.name, collection, snipe.userId);
-                }
+        let contentString = "";
+        const snipes = await localFunctions.getCollabSnipes(collab.name, collection, id);
+        if (typeof snipes !== "undefined") {
+            if (typeof snipes.find(p => p.pick === id) !== "undefined") {
+                contentString = "Snipers! ";
             }
-
-            const leaveEmbed = new EmbedBuilder()
-                .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setDescription(`**\`\`\`ml\n📣 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${pickFull.name}\nID: ${pickFull.id}`)
-                .setImage(pickFull.imgURL)
-            logChannel.send({ content: `${contentString}\nUser <@${fullParticipation.discordId}> has been removed from the collab.\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Removed by:** <@${int.user.id}>`, embeds: [leaveEmbed] });
-
-            const auditEmbed = new EmbedBuilder()
-                .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An user has been removed from the collab!**\n\n**Pick Name**: ${pickFull.name}\n**Pick ID**: ${pickFull.id}\n**Ex-Owner**: <@${fullParticipation.discordId}>\n**Removed by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
-            auditChannel.send({ content: '', embeds: [auditEmbed] });
-            await int.editReply('The user has been removed from the collab.');
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
+            for (const snipe of snipes) {
+                contentString = contentString.concat('', `<@${snipe.userId}>`);
+                await localFunctions.removeCollabSnipe(collab.name, collection, snipe.userId);
+            }
         }
-    },
+
+        const leaveEmbed = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setDescription(`**\`\`\`ml\n📣 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${pickFull.name}\nID: ${pickFull.id}`)
+            .setImage(pickFull.imgURL)
+        logChannel.send({ content: `${contentString}\nUser <@${fullParticipation.discordId}> has been removed from the collab.\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Removed by:** <@${int.user.id}>`, embeds: [leaveEmbed] });
+
+        const auditEmbed = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An user has been removed from the collab!**\n\n**Pick Name**: ${pickFull.name}\n**Pick ID**: ${pickFull.id}\n**Ex-Owner**: <@${fullParticipation.discordId}>\n**Removed by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
+        auditChannel.send({ content: '', embeds: [auditEmbed] });
+        await int.editReply('The user has been removed from the collab.');
+    }
 };

--- a/src/components/modals/remove-user-report.js
+++ b/src/components/modals/remove-user-report.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { reportCache } = require('../buttons/report-accept');
@@ -10,93 +9,86 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         const auditChannel = guild.channels.cache.get(localConstants.auditLogChannelID);
 
-        try {
-            const report = reportCache.get(int.user.id).report;
-            const collab = await localFunctions.getCollab(report.collab, collection);
-            const pickFull = collab.pool.items.find(e => e.id === report.pickId);
-            const message = reportCache.get(int.user.id).message;
-            const id = pickFull.id;
-            const fullParticipation = collab.participants.find((e) => e.id === id);
+        const report = reportCache.get(int.user.id).report;
+        const collab = await localFunctions.getCollab(report.collab, collection);
+        const pickFull = collab.pool.items.find(e => e.id === report.pickId);
+        const message = reportCache.get(int.user.id).message;
+        const id = pickFull.id;
+        const fullParticipation = collab.participants.find((e) => e.id === id);
 
-            let userCollabs = await localFunctions.getUserCollabs(fullParticipation.discordId, userCollection);
-            await localFunctions.unsetCollabParticipation(collab.name, collection, id);
-            userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
-            await localFunctions.setUserCollabs(fullParticipation.discordId, userCollabs, userCollection);
-            await localFunctions.removeCollabParticipant(collab.name, collection, fullParticipation.discordId);
-            await localFunctions.unsetParticipationOnSheet(collab, pickFull);
+        let userCollabs = await localFunctions.getUserCollabs(fullParticipation.discordId, userCollection);
+        await localFunctions.unsetCollabParticipation(collab.name, collection, id);
+        userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
+        await localFunctions.setUserCollabs(fullParticipation.discordId, userCollabs, userCollection);
+        await localFunctions.removeCollabParticipant(collab.name, collection, fullParticipation.discordId);
+        await localFunctions.unsetParticipationOnSheet(collab, pickFull);
 
-            const pendingMember = await guild.members.fetch(fullParticipation.discordId);
-            await pendingMember.roles.remove(collab.roleId);
+        const pendingMember = await guild.members.fetch(fullParticipation.discordId);
+        await pendingMember.roles.remove(collab.roleId);
 
-            let contentString = "";
-            const snipes = collab.snipes;
-            if (typeof snipes !== "undefined") {
-                if (typeof snipes.find(p => p.pick === id) !== "undefined") {
-                    contentString = "Snipers! ";
-                }
-                for (const snipe of snipes) {
-                    contentString = contentString.concat('', `<@${snipe.userId}>`);
-                    await localFunctions.removeCollabSnipe(collab.name, collection, snipe.userId);
-                }
+        let contentString = "";
+        const snipes = collab.snipes;
+        if (typeof snipes !== "undefined") {
+            if (typeof snipes.find(p => p.pick === id) !== "undefined") {
+                contentString = "Snipers! ";
             }
-
-            const leaveEmbed = new EmbedBuilder()
-                .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setDescription(`**\`\`\`ml\n📣 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${pickFull.name}\nID: ${pickFull.id}`)
-                .setImage(pickFull.imgURL)
-            logChannel.send({ content: `${contentString}\nUser <@${fullParticipation.discordId}> has been removed from the collab.\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Removed by:** <@${int.user.id}>`, embeds: [leaveEmbed] });
-
-            const auditEmbed = new EmbedBuilder()
-                .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An user has been removed from the collab!**\n\n**Pick Name**: ${pickFull.name}\n**Pick ID**: ${pickFull.id}\n**Ex-Owner**: <@${fullParticipation.discordId}>\n**Removed by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
-            auditChannel.send({ content: '', embeds: [auditEmbed] });
-
-            const reporterMember = await guild.members.cache.find(member => member.id === report.reporterUser);
-            try {
-                reporterMember.send({
-                    content: `Your report for the user <@${report.reportedUser}> has been accepted and the user has been kicked from the collab.`,
-                });
-            } catch (e) {
-                console.log(e);
-                const logChannel = guild.channels.cache.get(localConstants.logChannelID);
-                logChannel.send({
-                    content: `<@${report.reporterUser}> Your report for the user <@${report.reportedUser}> has been accepted and the user has been kicked from the collab.`,
-                });
+            for (const snipe of snipes) {
+                contentString = contentString.concat('', `<@${snipe.userId}>`);
+                await localFunctions.removeCollabSnipe(collab.name, collection, snipe.userId);
             }
-
-            let reportEmbed = new EmbedBuilder()
-                .setFooter({ text: "Endless Mirage | Report Accepted", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                .setColor('#f26e6a')
-                .setTimestamp()
-                .setURL('https://endlessmirage.net/')
-                .setDescription(`**\`\`\`📣 Report Accepted\`\`\`**\n**Action taken:** Kick\n**Admin:** <@${int.user.id}>`)
-                .addFields(
-                    {
-                        name: report.embed.data.fields[0].name,
-                        value: report.embed.data.fields[0].value
-                    },
-                    {
-                        name: report.embed.data.fields[1].name,
-                        value: report.embed.data.fields[1].value
-                    }
-                )
-
-            await message.edit({ embeds: [reportEmbed], components: [] });
-            await localFunctions.liquidateReport(report._id);
-            await int.editReply('The user has been removed from the collab.');
-
-
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
         }
-    },
+
+        const leaveEmbed = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setDescription(`**\`\`\`ml\n📣 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${pickFull.name}\nID: ${pickFull.id}`)
+            .setImage(pickFull.imgURL)
+        logChannel.send({ content: `${contentString}\nUser <@${fullParticipation.discordId}> has been removed from the collab.\n**Reason:** ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}\n**Removed by:** <@${int.user.id}>`, embeds: [leaveEmbed] });
+
+        const auditEmbed = new EmbedBuilder()
+            .setFooter({ text: 'Endless Mirage | Audit Log', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setDescription(`**\`\`\`ml\n📣 New Action Taken\`\`\`**                                                                                                        **An user has been removed from the collab!**\n\n**Pick Name**: ${pickFull.name}\n**Pick ID**: ${pickFull.id}\n**Ex-Owner**: <@${fullParticipation.discordId}>\n**Removed by**: <@${int.user.id}>\n**Reason**: ${int.fields.getTextInputValue('reason') ? int.fields.getTextInputValue('reason') : "None"}`);
+        auditChannel.send({ content: '', embeds: [auditEmbed] });
+
+        const reporterMember = await guild.members.cache.find(member => member.id === report.reporterUser);
+        try {
+            reporterMember.send({
+                content: `Your report for the user <@${report.reportedUser}> has been accepted and the user has been kicked from the collab.`,
+            });
+        } catch (e) {
+            console.log(e);
+            const logChannel = guild.channels.cache.get(localConstants.logChannelID);
+            logChannel.send({
+                content: `<@${report.reporterUser}> Your report for the user <@${report.reportedUser}> has been accepted and the user has been kicked from the collab.`,
+            });
+        }
+
+        let reportEmbed = new EmbedBuilder()
+            .setFooter({ text: "Endless Mirage | Report Accepted", iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+            .setColor('#f26e6a')
+            .setTimestamp()
+            .setURL('https://endlessmirage.net/')
+            .setDescription(`**\`\`\`📣 Report Accepted\`\`\`**\n**Action taken:** Kick\n**Admin:** <@${int.user.id}>`)
+            .addFields(
+                {
+                    name: report.embed.data.fields[0].name,
+                    value: report.embed.data.fields[0].value
+                },
+                {
+                    name: report.embed.data.fields[1].name,
+                    value: report.embed.data.fields[1].value
+                }
+            )
+
+        await message.edit({ embeds: [reportEmbed], components: [] });
+        await localFunctions.liquidateReport(report._id);
+        await int.editReply('The user has been removed from the collab.');
+    }
 };

--- a/src/components/modals/reset-collab.js
+++ b/src/components/modals/reset-collab.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { resetCache } = require('../buttons/reset-collab');
 
@@ -8,25 +7,20 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply();
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
         
-        try {
-            let name = int.fields.getTextInputValue('name');
-            if (resetCache.get(int.user.id).collab.host === int.user.id && resetCache.get(int.user.id).collab.name === name) {
-                await localFunctions.liquidateCollabUsers(resetCache.get(int.user.id).collab.name, collection);
-                await localFunctions.liquidateCollabFromUsers(resetCache.get(int.user.id).collab.name, userCollection);
-                await localFunctions.resetPick(resetCache.get(int.user.id).collab.name, collection);
-                await localFunctions.setSheetFromZero(resetCache.get(int.user.id).collab, resetCache.get(int.user.id).collab.pool.items);
-                await int.editReply('The collab\'s picks have been reset.');
-                resetCache.delete(int.user.id);
-            } else {
-                await int.editReply('Verification for reset failed.');
-                return;
-            }
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
+        let name = int.fields.getTextInputValue('name');
+        if (resetCache.get(int.user.id).collab.host === int.user.id && resetCache.get(int.user.id).collab.name === name) {
+            await localFunctions.liquidateCollabUsers(resetCache.get(int.user.id).collab.name, collection);
+            await localFunctions.liquidateCollabFromUsers(resetCache.get(int.user.id).collab.name, userCollection);
+            await localFunctions.resetPick(resetCache.get(int.user.id).collab.name, collection);
+            await localFunctions.setSheetFromZero(resetCache.get(int.user.id).collab, resetCache.get(int.user.id).collab.pool.items);
+            await int.editReply('The collab\'s picks have been reset.');
+            resetCache.delete(int.user.id);
+        } else {
+            await int.editReply('Verification for reset failed.');
+            return;
         }
-    },
+    }
 };

--- a/src/components/modals/start-bump.js
+++ b/src/components/modals/start-bump.js
@@ -1,6 +1,5 @@
 const { EmbedBuilder } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 
@@ -12,7 +11,7 @@ module.exports = {
   async execute(int, client) {
     await int.deferReply({ ephemeral: true });
     const guild = client.guilds.cache.get(localConstants.guildId);
-    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
+    const collection = client.db.collection("Collabs");
     const currentDate = Math.floor(Date.now() / 1000);
     const duration = parseInt(int.fields.getTextInputValue('duration'));
     if (isNaN(duration)) return int.editReply('Provide a valid number of days.');
@@ -54,8 +53,6 @@ module.exports = {
       }
     } catch (e) {
       console.log(e);
-    } finally {
-      mongoClient.close();
     }
-  },
+  }
 };

--- a/src/components/modals/sub-cancel.js
+++ b/src/components/modals/sub-cancel.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -7,18 +6,14 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
         let cancel = int.fields.getTextInputValue('cancel');
 
-        try {
-            if (cancel === "yes") {
-                await localFunctions.setSubStatus(int.user.id, collection, "innactive");
-                return int.editReply('Your monthly subscription has been canceled.');
-            } else {
-                return int.editReply('Invalid action.');
-            }
-        } finally {
-            mongoClient.close();
+        if (cancel === "yes") {
+            await localFunctions.setSubStatus(int.user.id, collection, "innactive");
+            return int.editReply('Your monthly subscription has been canceled.');
+        } else {
+            return int.editReply('Invalid action.');
         }
-    },
+    }
 };

--- a/src/components/modals/sub-change-amount.js
+++ b/src/components/modals/sub-change-amount.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -7,7 +6,8 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
+
         let newAmmount = parseFloat(int.fields.getTextInputValue('newAmmount'));
         if (isNaN(newAmmount)) {
             return int.editReply('Invalid amount!');
@@ -15,11 +15,7 @@ module.exports = {
             return int.editReply('Invalid amount! Use a number that is greater or equal to 5 and not decimal.');
         }
 
-        try {
-            await localFunctions.setSubAmount(int.user.id, collection, newAmmount);
-            return int.editReply('Your monthly subscription amount has been edited! Run /premium to check it.');
-        } finally {
-            mongoClient.close();
-        }
-    },
+        await localFunctions.setSubAmount(int.user.id, collection, newAmmount);
+        return int.editReply('Your monthly subscription amount has been edited! Run /premium to check it.');
+    }
 };

--- a/src/components/modals/suggestion-approval.js
+++ b/src/components/modals/suggestion-approval.js
@@ -1,6 +1,5 @@
 const { SuggestionCache } = require('../buttons/suggestion-approve');
 const { EmbedBuilder } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -9,54 +8,53 @@ module.exports = {
     },
     async execute (int, client) {
         await int.deferReply({ ephemeral: true });
-        const reward = Math.min(parseInt(int.fields.getTextInputValue("reward")),5000);
+        const reward = Math.min(parseInt(int.fields.getTextInputValue("reward")), 5000);
+
         if (!Number.isInteger(reward)) {
             await int.editReply({content: 'Invalid amount of tokens.', ephemeral: true});
             return;
         }
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+
+        const collection = client.db.collection("OzenCollection");
         const logChannel = int.guild.channels.cache.get('1152347792539402250');
-        try {
-            const suggestionMessage = SuggestionCache.get(int.user.id).message;
-            const suggestion = await localFunctions.getSuggestion(suggestionMessage.id);
-            const currentBalance = await localFunctions.getBalance(suggestion.user, collection);
-            if (suggestion.upvotes-suggestion.downvotes < 1) {
-                await int.editReply({content: 'There is not enough net upvotes for this to go trough. 1 is minimal.', ephemeral: true});
-                return;
-            }
-            const reason = int.fields.getTextInputValue("text-reason");
-            let status = 'Approved.';
-            const updatedEmbed = new EmbedBuilder()
-                .setThumbnail(suggestion.embed.data.thumbnail.url)
-                .setAuthor({
-                    name: suggestion.embed.data.author.name,
-                    iconURL: suggestion.embed.data.author.icon_url
-                })
-                .setColor('#f26e6a')
-                .setImage('https://puu.sh/JPffc/3c792e61c9.png')
-                .setTimestamp()
-                .setDescription(suggestion.embed.data.description)
-                .addFields(
-                    { name: '\u200B', value: `**Status: ${status}**\n\n🔺 Total Upvote count: ${suggestion.upvotes}.\n🔻 Total Downvote count: ${suggestion.downvotes}.\n🟢 Approved by <@${int.user.id}>\nReason: ${reason}` },
-                );
-            suggestionMessage.edit({ embeds: [updatedEmbed], components: [] });
-            const newBalance = currentBalance + reward;
-            await localFunctions.setBalance(suggestion.user, newBalance, collection);
-            suggestionMessage.reply(`<@${suggestion.user}> Your suggestion has been approved and you've obtained ${reward} ₥.`);
-            await localFunctions.liquidateSuggestion(suggestionMessage.id);
-            const logEmbed = new EmbedBuilder()
-              .setColor('#f26e6a')
-              .setImage('https://puu.sh/JPffc/3c792e61c9.png')
-              .setAuthor({ name: "🟢 New suggestion approved.", iconURL: suggestion.embed.data.author.icon_url })
-              .setThumbnail('https://puu.sh/JP9Iw/a365159d0e.png')
-              .setDescription(`**Suggested by <@${suggestion.user}>\nApproved by <@${int.user.id}>**\n\n${suggestion.embed.data.description}\n\nDate: <t:${Math.floor(new Date(Date.now()) / 1000)}:F>.`)
-            logChannel.send({ content: '', embeds: [logEmbed] });
-            SuggestionCache.delete(int.user.id);
-            await int.editReply({ content: 'Suggestion successfully approved.', ephemeral: true });
-        } finally {
-            if (mongoClient) {
-                mongoClient.close();
-            }
+        
+        const suggestionMessage = SuggestionCache.get(int.user.id).message;
+        const suggestion = await localFunctions.getSuggestion(suggestionMessage.id);
+        const currentBalance = await localFunctions.getBalance(suggestion.user, collection);
+        
+        if (suggestion.upvotes-suggestion.downvotes < 1) {
+            await int.editReply({content: 'There is not enough net upvotes for this to go trough. 1 is minimal.', ephemeral: true});
+            return;
         }
-    },
+        
+        const reason = int.fields.getTextInputValue("text-reason");
+        let status = 'Approved.';
+        const updatedEmbed = new EmbedBuilder()
+            .setThumbnail(suggestion.embed.data.thumbnail.url)
+            .setAuthor({
+                name: suggestion.embed.data.author.name,
+                iconURL: suggestion.embed.data.author.icon_url
+            })
+            .setColor('#f26e6a')
+            .setImage('https://puu.sh/JPffc/3c792e61c9.png')
+            .setTimestamp()
+            .setDescription(suggestion.embed.data.description)
+            .addFields(
+                { name: '\u200B', value: `**Status: ${status}**\n\n🔺 Total Upvote count: ${suggestion.upvotes}.\n🔻 Total Downvote count: ${suggestion.downvotes}.\n🟢 Approved by <@${int.user.id}>\nReason: ${reason}` },
+            );
+        suggestionMessage.edit({ embeds: [updatedEmbed], components: [] });
+        const newBalance = currentBalance + reward;
+        await localFunctions.setBalance(suggestion.user, newBalance, collection);
+        suggestionMessage.reply(`<@${suggestion.user}> Your suggestion has been approved and you've obtained ${reward} ₥.`);
+        await localFunctions.liquidateSuggestion(suggestionMessage.id);
+        const logEmbed = new EmbedBuilder()
+            .setColor('#f26e6a')
+            .setImage('https://puu.sh/JPffc/3c792e61c9.png')
+            .setAuthor({ name: "🟢 New suggestion approved.", iconURL: suggestion.embed.data.author.icon_url })
+            .setThumbnail('https://puu.sh/JP9Iw/a365159d0e.png')
+            .setDescription(`**Suggested by <@${suggestion.user}>\nApproved by <@${int.user.id}>**\n\n${suggestion.embed.data.description}\n\nDate: <t:${Math.floor(new Date(Date.now()) / 1000)}:F>.`)
+        logChannel.send({ content: '', embeds: [logEmbed] });
+        SuggestionCache.delete(int.user.id);
+        await int.editReply({ content: 'Suggestion successfully approved.', ephemeral: true });
+    }
 };

--- a/src/components/modals/swap-pick.js
+++ b/src/components/modals/swap-pick.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
@@ -11,9 +10,9 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB('Special');
+        const collection = client.db.collection("Collabs");
+        const userCollection = client.db.collection("OzenCollection");
+        const collectionSpecial = client.db.collection("Special");
         const userId = int.user.id;
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
@@ -137,10 +136,6 @@ module.exports = {
             }
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
-            mongoClientUsers.close();
-            mongoClientSpecial.close();
         }
-    },
+    }
 };

--- a/src/components/modals/trade-pick.js
+++ b/src/components/modals/trade-pick.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
@@ -23,7 +22,8 @@ module.exports = {
                 initializedMap = profileButtonCache;
             }
         }
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB('Special');
+
+        const collectionSpecial = client.db.collection("Special");
         const userId = int.user.id;
         const guild = client.guilds.cache.get(localConstants.guildId);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
@@ -116,16 +116,13 @@ module.exports = {
                     'messageId': message.id,
                     'messageUrl': message.url,
                     'collabName': collab.name
-                }
+                };
 
                 await localFunctions.updateTradeRequest(tradeData, collectionSpecial);
-
                 await int.editReply(`New trade request created in <#${localConstants.logChannelID}>`);
             }
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClientSpecial.close();
         }
     },
 };

--- a/src/components/modals/verify-payment-sub.js
+++ b/src/components/modals/verify-payment-sub.js
@@ -1,7 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
-const { connectToMongoDB } = require('../../mongo');
 
 module.exports = {
   data: {
@@ -10,100 +9,95 @@ module.exports = {
   async execute(int, client) {
     await int.deferReply({ ephemeral: true });
     const userId = int.user.id;
-    const { collection: collectionPayments, client: mongoClientPayments } = await connectToMongoDB("PD");
-    const { collection: collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+    const collectionPayments = client.db.collection("PD");
+    const collection = client.db.collection("OzenCollection");
     const email = int.fields.getTextInputValue("email");
     const guild = client.guilds.cache.get(localConstants.guildId);
     let pendingMember = await guild.members.cache.get(userId);
 
-    try {
-      let paymentData = await localFunctions.getPaymentInfo(email, collectionPayments);
-      let user = await localFunctions.getUser(userId, collection);
-      let userSubAmount = parseInt(user.monthlyDonation.currentAmount);
-      if (paymentData.length !== 0) {
-        if (userSubAmount === parseInt(paymentData.amount)) {
-          const currentDate = new Date();
-          const day = currentDate.getDate();
-          const month = currentDate.getMonth() + 1;
-          const year = currentDate.getFullYear();
-          const formattedDay = String(day).padStart(2, '0');
-          const formattedMonth = String(month).padStart(2, '0');
-          const formattedDate = `${formattedDay}/${formattedMonth}/${year}`;
-          console.log('A new sub payment has been verified.');
-          let userSubData = user.monthlyDonation;
-          userSubData.lastDate = formattedDate;
-          userSubData.status = "paid";
-          let newTotal = parseInt(userSubData.total) + userSubAmount;
-          userSubData.total = newTotal.toString();
+    let paymentData = await localFunctions.getPaymentInfo(email, collectionPayments);
+    let user = await localFunctions.getUser(userId, collection);
+    let userSubAmount = parseInt(user.monthlyDonation.currentAmount);
+    if (paymentData.length !== 0) {
+      if (userSubAmount === parseInt(paymentData.amount)) {
+        const currentDate = new Date();
+        const day = currentDate.getDate();
+        const month = currentDate.getMonth() + 1;
+        const year = currentDate.getFullYear();
+        const formattedDay = String(day).padStart(2, '0');
+        const formattedMonth = String(month).padStart(2, '0');
+        const formattedDate = `${formattedDay}/${formattedMonth}/${year}`;
+        console.log('A new sub payment has been verified.');
+        let userSubData = user.monthlyDonation;
+        userSubData.lastDate = formattedDate;
+        userSubData.status = "paid";
+        let newTotal = parseInt(userSubData.total) + userSubAmount;
+        userSubData.total = newTotal.toString();
 
-          const subLogEmbed = new EmbedBuilder()
-            .setAuthor({ name: "✔️ New Subscription Payment." })
-            .setThumbnail(int.user.displayAvatarURL())
-            .setFooter({ text: 'Endless Mirage', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-            .setColor('#f26e6a')
-            .setDescription(`**Amount payed: ${userSubAmount}$**\n**Payment made by <@${userId}>**\n**Payment method: ${paymentData.type}**`)
-            .setTimestamp();
+        const subLogEmbed = new EmbedBuilder()
+          .setAuthor({ name: "✔️ New Subscription Payment." })
+          .setThumbnail(int.user.displayAvatarURL())
+          .setFooter({ text: 'Endless Mirage', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+          .setColor('#f26e6a')
+          .setDescription(`**Amount payed: ${userSubAmount}$**\n**Payment made by <@${userId}>**\n**Payment method: ${paymentData.type}**`)
+          .setTimestamp();
 
-          await localFunctions.setFullSubStatus(userId, userSubData, collection);
+        await localFunctions.setFullSubStatus(userId, userSubData, collection);
 
-          let userTier = await localFunctions.getUserTier(userId, collection);
-          if (userTier.name === "Mirage X") {
-            userTier.name === "Mirage VII";
+        let userTier = await localFunctions.getUserTier(userId, collection);
+        if (userTier.name === "Mirage X") {
+          userTier.name === "Mirage VII";
+        }
+        const fullTier = localConstants.premiumTiers[localFunctions.premiumToInteger(userTier.name) - 1];
+        let nextTier;
+        if (fullTier.name !== "Mirage VII") {
+          nextTier = localConstants.premiumTiers[localFunctions.premiumToInteger(userTier.name)];
+        } else {
+          nextTier = fullTier;
+        }
+        if (nextTier !== fullTier && newTotal >= nextTier.cost) {
+          let perksToAssign = [];
+          let allPerksForTier = await localFunctions.getFullPerksOfTierWNR(localFunctions.premiumToInteger(nextTier.name));
+          for (let perk of allPerksForTier) {
+            perksToAssign.push(perk);
           }
-          const fullTier = localConstants.premiumTiers[localFunctions.premiumToInteger(userTier.name) - 1];
-          let nextTier;
-          if (fullTier.name !== "Mirage VII") {
-            nextTier = localConstants.premiumTiers[localFunctions.premiumToInteger(userTier.name)];
-          } else {
-            nextTier = fullTier;
-          }
-          if (nextTier !== fullTier && newTotal >= nextTier.cost) {
+          userTier.name = nextTier.name;
+          userTier.id = nextTier.roleId;
+          await pendingMember.roles.remove(fullTier.roleId);
+          await pendingMember.roles.add(nextTier.roleId);
+          await pendingMember.roles.add('743505566617436301');
+          await localFunctions.setUserTier(userId, userTier, collection);
+          await localFunctions.setPerks(userId, perksToAssign, collection);
+          console.log(`Tier upgrade has been executed due to monthly support renewal for ${int.user.tag}.`);
+          await int.editReply({
+            content: 'Your payment has been verified and your tier has been upgraded! Thank you for your renewal <3, check your new status using /premium.'
+          });
+        } else {
+          if (fullTier.generalRenewalPrice === null || userSubData.total >= fullTier.generalRenewalPrice) {
             let perksToAssign = [];
-            let allPerksForTier = await localFunctions.getFullPerksOfTierWNR(localFunctions.premiumToInteger(nextTier.name));
+            let allPerksForTier = await localFunctions.getFullPerksOfTier(localFunctions.premiumToInteger(userTier.name));
             for (let perk of allPerksForTier) {
               perksToAssign.push(perk);
             }
-            userTier.name = nextTier.name;
-            userTier.id = nextTier.roleId;
-            await pendingMember.roles.remove(fullTier.roleId);
-            await pendingMember.roles.add(nextTier.roleId);
-            await pendingMember.roles.add('743505566617436301');
-            await localFunctions.setUserTier(userId, userTier, collection);
             await localFunctions.setPerks(userId, perksToAssign, collection);
-            console.log(`Tier upgrade has been executed due to monthly support renewal for ${int.user.tag}.`);
-            await int.editReply({
-              content: 'Your payment has been verified and your tier has been upgraded! Thank you for your renewal <3, check your new status using /premium.'
-            })
-          } else {
-            if (fullTier.generalRenewalPrice === null || userSubData.total >= fullTier.generalRenewalPrice) {
-              let perksToAssign = [];
-              let allPerksForTier = await localFunctions.getFullPerksOfTier(localFunctions.premiumToInteger(userTier.name));
-              for (let perk of allPerksForTier) {
-                perksToAssign.push(perk);
-              }
-              await localFunctions.setPerks(userId, perksToAssign, collection);
-              console.log(`Full renewal of perks has been executed due to monthly support renewal for ${int.user.tag}.`)
-            }
-            await int.editReply({
-              content: 'Your payment has been verified! Thank you for your renewal <3, check your new status using /premium.'
-            })
+            console.log(`Full renewal of perks has been executed due to monthly support renewal for ${int.user.tag}.`)
           }
-          const premiumLogChannel = guild.channels.cache.get('1195256632318365746');
-          premiumLogChannel.send({ content: '', embeds: [subLogEmbed] });
-          await localFunctions.liquidatePaymentData(email, collectionPayments);
-        } else {
           await int.editReply({
-            content: 'A payment with a different amount has been found. If you sent the wrong amount, DM <@687004886922952755> for a refund or if you think this is a mistake.'
-          })
+            content: 'Your payment has been verified! Thank you for your renewal <3, check your new status using /premium.'
+          });
         }
+        const premiumLogChannel = guild.channels.cache.get('1195256632318365746');
+        premiumLogChannel.send({ content: '', embeds: [subLogEmbed] });
+        await localFunctions.liquidatePaymentData(email, collectionPayments);
       } else {
         await int.editReply({
-          content: 'Your payment hasn\'t been found. Please make sure you typed your email right in the form. Try again or in case you\'re sure you didn\'t make a typo, contact the owner <@687004886922952755>'
-        })
+          content: 'A payment with a different amount has been found. If you sent the wrong amount, DM <@687004886922952755> for a refund or if you think this is a mistake.'
+        });
       }
-    } finally {
-      mongoClientPayments.close();
-      mongoClient.close();
+    } else {
+      await int.editReply({
+        content: 'Your payment hasn\'t been found. Please make sure you typed your email right in the form. Try again or in case you\'re sure you didn\'t make a typo, contact the owner <@687004886922952755>'
+      });
     }
-  },
+  }
 };

--- a/src/components/modals/verify-paypal.js
+++ b/src/components/modals/verify-paypal.js
@@ -1,7 +1,6 @@
 const { EmbedBuilder } = require('discord.js');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
-const { connectToMongoDB } = require('../../mongo');
 
 module.exports = {
   data: {
@@ -10,118 +9,113 @@ module.exports = {
   async execute(int, client) {
     await int.deferReply({ ephemeral: true });
     const userId = int.user.id;
-    const { collection: collectionPayments, client: mongoClientPayments } = await connectToMongoDB("PD");
-    const { collection: collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+    const collectionPayments = client.db.collection("PD");
+    const collection = client.db.collection("OzenCollection");
     const email = int.fields.getTextInputValue("email");
     const guild = client.guilds.cache.get(localConstants.guildId);
 
-    try {
-      let paymentData = await localFunctions.getPaymentInfo(email, collectionPayments);
-      let userPendingAmount = await localFunctions.getPendingPaymentAmount(userId, collection);
-      let currentTier = await localFunctions.getUserTier(userId, collection);
-      if (paymentData.length !== 0) {
-        if (userPendingAmount === parseInt(paymentData.amount)) {
-          console.log('A new payment has been verified');
-          const pendingMember = await guild.members.fetch(userId);
-          let perksToAssign = [];
-          let userPerks = await localFunctions.getPerks(userId, collection);
-          if (userPerks.length !== 0) {
-            perksToAssign = userPerks;
-          }
-          let allPerksForTier = [];
-          let userCart = await localFunctions.getCart(userId, collection);
-          const premiumLogEmbed = new EmbedBuilder()
-            .setAuthor({ name: "✔️ A new premium purchase has been made." })
-            .setThumbnail(int.user.displayAvatarURL())
-            .setFooter({ text: 'Endless Mirage', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-            .setColor('#f26e6a')
-            .setDescription(`**Total amount payed: ${userPendingAmount}$**\n**Purchase made by <@${userId}>**\n**Payment method: ${paymentData.type}**`)
-            .setTimestamp();
-
-          for (let item of userCart) {
-            let fullPerk = localConstants.premiumPerks.find(e => e.name === item.name);
-            premiumLogEmbed.addFields(
-              {
-                name: "᲼",
-                value: `**\`\`🔗 ${item.name}\`\`**\n ├ Type: ${item.type}\n └ Price: ${item.price}$`,
-              },
-            )
-            switch (item.type) {
-              case 'Tier':
-                allPerksForTier = await localFunctions.getFullPerksOfTierWNR(localFunctions.premiumToInteger(item.name));
-                for (let perk of allPerksForTier) {
-                  if (typeof userPerks.find((e) => e.name === perk.name) === "undefined") {
-                    perksToAssign.push(perk);
-                  }
-                }
-                for (let tier of localConstants.premiumTiers) {
-                  if (tier.name === item.name) {
-                    await pendingMember.roles.add(tier.roleId);
-                    await pendingMember.roles.add('743505566617436301');
-                    await localFunctions.assignPremium(userId, pendingMember, collection);
-                    break;
-                  }
-                }
-                break;
-              case 'Perk':
-                if (userPerks.length !== 0) {
-                  perksToAssign = userPerks;
-                }
-                perksToAssign.push(fullPerk);
-                break;
-              case 'Upgrade':
-                await pendingMember.roles.remove(currentTier.id);
-                allPerksForTier = await localFunctions.getFullPerksOfTierWNR(localFunctions.premiumToInteger(item.name));
-                for (let perk of allPerksForTier) {
-                  if (typeof userPerks.find((e) => e.name === perk.name) === "undefined") {
-                    perksToAssign.push(perk);
-                  }
-                }
-                for (let tier of localConstants.premiumTiers) {
-                  if (tier.name === item.name) {
-                    await pendingMember.roles.add(tier.roleId);
-                    break;
-                  }
-                }
-                currentTier.name = item.name;
-                await localFunctions.setUserTier(userId, currentTier, collection);
-                break;
-              case 'Renewal':
-                if (item.class === "Perk") {
-                  let fullRenewal = localConstants.premiumPerks.find(e => e.name === item.name);
-                  perksToAssign.push(fullRenewal);
-                  break;
-                } else if (item.class === "Tier") {
-                  allPerksForTier = await localFunctions.getFullPerksOfTierWNR(localFunctions.premiumToInteger(item.name));
-                  for (let perk of allPerksForTier) {
-                    if (typeof userPerks.find((e) => e.name === perk.name) === "undefined") {
-                      perksToAssign.push(perk);
-                    }
-                  }
-                }
-            }
-          }
-          await localFunctions.delCart(userId, collection);
-          await localFunctions.setPerks(userId, perksToAssign, collection);
-          await localFunctions.liquidatePaymentData(email, collectionPayments);
-          await int.editReply({
-            content: 'Your payment has been verified! Thank you for your purchase, check your new status using /premium.'
-          })
-          const premiumLogChannel = guild.channels.cache.get('1195256632318365746');
-          premiumLogChannel.send({ content: '', embeds: [premiumLogEmbed] });
-        } else {
-          await int.editReply({
-            content: 'A payment with a different amount has been found. If you sent the wrong amount, DM <@687004886922952755> for a refund or if you think this is a mistake.'
-          })
+    let paymentData = await localFunctions.getPaymentInfo(email, collectionPayments);
+    let userPendingAmount = await localFunctions.getPendingPaymentAmount(userId, collection);
+    let currentTier = await localFunctions.getUserTier(userId, collection);
+    if (paymentData.length !== 0) {
+      if (userPendingAmount === parseInt(paymentData.amount)) {
+        console.log('A new payment has been verified');
+        const pendingMember = await guild.members.fetch(userId);
+        let perksToAssign = [];
+        let userPerks = await localFunctions.getPerks(userId, collection);
+        if (userPerks.length !== 0) {
+          perksToAssign = userPerks;
         }
+        let allPerksForTier = [];
+        let userCart = await localFunctions.getCart(userId, collection);
+        const premiumLogEmbed = new EmbedBuilder()
+          .setAuthor({ name: "✔️ A new premium purchase has been made." })
+          .setThumbnail(int.user.displayAvatarURL())
+          .setFooter({ text: 'Endless Mirage', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+          .setColor('#f26e6a')
+          .setDescription(`**Total amount payed: ${userPendingAmount}$**\n**Purchase made by <@${userId}>**\n**Payment method: ${paymentData.type}**`)
+          .setTimestamp();
+
+        for (let item of userCart) {
+          let fullPerk = localConstants.premiumPerks.find(e => e.name === item.name);
+          premiumLogEmbed.addFields(
+            {
+              name: "᲼",
+              value: `**\`\`🔗 ${item.name}\`\`**\n ├ Type: ${item.type}\n └ Price: ${item.price}$`,
+            },
+          )
+          switch (item.type) {
+            case 'Tier':
+              allPerksForTier = await localFunctions.getFullPerksOfTierWNR(localFunctions.premiumToInteger(item.name));
+              for (let perk of allPerksForTier) {
+                if (typeof userPerks.find((e) => e.name === perk.name) === "undefined") {
+                  perksToAssign.push(perk);
+                }
+              }
+              for (let tier of localConstants.premiumTiers) {
+                if (tier.name === item.name) {
+                  await pendingMember.roles.add(tier.roleId);
+                  await pendingMember.roles.add('743505566617436301');
+                  await localFunctions.assignPremium(userId, pendingMember, collection);
+                  break;
+                }
+              }
+              break;
+            case 'Perk':
+              if (userPerks.length !== 0) {
+                perksToAssign = userPerks;
+              }
+              perksToAssign.push(fullPerk);
+              break;
+            case 'Upgrade':
+              await pendingMember.roles.remove(currentTier.id);
+              allPerksForTier = await localFunctions.getFullPerksOfTierWNR(localFunctions.premiumToInteger(item.name));
+              for (let perk of allPerksForTier) {
+                if (typeof userPerks.find((e) => e.name === perk.name) === "undefined") {
+                  perksToAssign.push(perk);
+                }
+              }
+              for (let tier of localConstants.premiumTiers) {
+                if (tier.name === item.name) {
+                  await pendingMember.roles.add(tier.roleId);
+                  break;
+                }
+              }
+              currentTier.name = item.name;
+              await localFunctions.setUserTier(userId, currentTier, collection);
+              break;
+            case 'Renewal':
+              if (item.class === "Perk") {
+                let fullRenewal = localConstants.premiumPerks.find(e => e.name === item.name);
+                perksToAssign.push(fullRenewal);
+                break;
+              } else if (item.class === "Tier") {
+                allPerksForTier = await localFunctions.getFullPerksOfTierWNR(localFunctions.premiumToInteger(item.name));
+                for (let perk of allPerksForTier) {
+                  if (typeof userPerks.find((e) => e.name === perk.name) === "undefined") {
+                    perksToAssign.push(perk);
+                  }
+                }
+              }
+          }
+        }
+        await localFunctions.delCart(userId, collection);
+        await localFunctions.setPerks(userId, perksToAssign, collection);
+        await localFunctions.liquidatePaymentData(email, collectionPayments);
+        await int.editReply({
+          content: 'Your payment has been verified! Thank you for your purchase, check your new status using /premium.'
+        })
+        const premiumLogChannel = guild.channels.cache.get('1195256632318365746');
+        premiumLogChannel.send({ content: '', embeds: [premiumLogEmbed] });
       } else {
         await int.editReply({
-          content: 'Your payment hasn\'t been found. Please make sure you typed your email right in the form. Try again or in case you\'re sure you didn\'t make a typo, contact the owner <@687004886922952755>'
-        })
+          content: 'A payment with a different amount has been found. If you sent the wrong amount, DM <@687004886922952755> for a refund or if you think this is a mistake.'
+        });
       }
-    } finally {
-      mongoClientPayments.close();
-      mongoClient.close();
+    } else {
+      await int.editReply({
+        content: 'Your payment hasn\'t been found. Please make sure you typed your email right in the form. Try again or in case you\'re sure you didn\'t make a typo, contact the owner <@687004886922952755>'
+      });
     }
-  },
+  }
 };

--- a/src/components/selectMenus/add-content-to-cart.js
+++ b/src/components/selectMenus/add-content-to-cart.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const { EmbedBuilder } = require('discord.js');
@@ -13,7 +12,7 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = client.db.collection("OzenCollection");
         const allMaps = [premiumBuyCache, perkCache, upgradeCache];
         const userId = int.user.id;
         const pendingItems = int.values;
@@ -292,9 +291,6 @@ module.exports = {
         } catch (e) {
             await int.editReply("Please reopen the menu if you desire to add another item to your cart!");
             console.log(e);
-            mongoClient.close();
-        } finally {
-            mongoClient.close();
         }
     }
 }

--- a/src/components/selectMenus/buy-item.js
+++ b/src/components/selectMenus/buy-item.js
@@ -1,5 +1,4 @@
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const userConfirmationCache = new Map();
@@ -14,49 +13,45 @@ module.exports = {
     const selectedItem = localConstants.shopItems.find((item) => item.name === itemName);
     if (!itemName || !selectedItem) return;
 
-    const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+    const collection = client.db.collection("OzenCollection");
 
     if ((selectedItem.name === "Novice Active Member Role" && int.member.roles.cache.has('1150870507445563452')) || (selectedItem.name === "Advanced Active Member Role" && int.member.roles.cache.has('1150870529104949330')) || (selectedItem.name === "Ultimate Active Member Role" && int.member.roles.cache.has('1150870546842660904'))) {
       int.reply({ content: "You already have this item active!", ephemeral: true });
       return;
     }
 
-    try {
-      const currentBalance = await localFunctions.getBalance(userId, collection); // Fetch user's balance from the database
-      let userInventory = await localFunctions.getInventory(userId, collection) || [];
+    const currentBalance = await localFunctions.getBalance(userId, collection); // Fetch user's balance from the database
+    let userInventory = await localFunctions.getInventory(userId, collection) || [];
 
-      if (parseInt(currentBalance) >= selectedItem.value_int && !userInventory.some((item) => item.name === selectedItem.name)) {
-        // Create a verification message with Yes and No buttons
-        const verificationMessage = await int.reply({
-          content: `Are you sure you want to buy ${selectedItem.name} for ${selectedItem.value}?`,
-          components: [
-            new ActionRowBuilder().addComponents(
-              new ButtonBuilder()
-                .setCustomId('buy-yes')
-                .setLabel('Yes')
-                .setStyle('Success'),
-              new ButtonBuilder()
-                .setCustomId('buy-no')
-                .setLabel('No')
-                .setStyle('Danger')
-            ),
-          ],
-          ephemeral: true,
-        });
+    if (parseInt(currentBalance) >= selectedItem.value_int && !userInventory.some((item) => item.name === selectedItem.name)) {
+      // Create a verification message with Yes and No buttons
+      const verificationMessage = await int.reply({
+        content: `Are you sure you want to buy ${selectedItem.name} for ${selectedItem.value}?`,
+        components: [
+          new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+              .setCustomId('buy-yes')
+              .setLabel('Yes')
+              .setStyle('Success'),
+            new ButtonBuilder()
+              .setCustomId('buy-no')
+              .setLabel('No')
+              .setStyle('Danger')
+          ),
+        ],
+        ephemeral: true,
+      });
 
-        // Store the item and the verification message ID in a temporary cache
-        userConfirmationCache.set(int.user.id, {
-          item: selectedItem,
-          verificationMessageId: verificationMessage.id,
-          verificationMessageChannel: int.channel.id,
-        });
-      } else if (userInventory.some((item) => item.name === selectedItem.name)) {
-        int.reply({ content: `You already have ${selectedItem.name}.`, ephemeral: true });
-      } else {
-        int.reply({ content: 'You do not have enough tokens to make this purchase.', ephemeral: true });
-      }
-    } finally {
-      mongoClient.close();
+      // Store the item and the verification message ID in a temporary cache
+      userConfirmationCache.set(int.user.id, {
+        item: selectedItem,
+        verificationMessageId: verificationMessage.id,
+        verificationMessageChannel: int.channel.id,
+      });
+    } else if (userInventory.some((item) => item.name === selectedItem.name)) {
+      await int.reply({ content: `You already have ${selectedItem.name}.`, ephemeral: true });
+    } else {
+      await int.reply({ content: 'You do not have enough tokens to make this purchase.', ephemeral: true });
     }
   },
   userConfirmationCache: userConfirmationCache

--- a/src/components/selectMenus/delete-cart-items.js
+++ b/src/components/selectMenus/delete-cart-items.js
@@ -1,5 +1,4 @@
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -9,24 +8,21 @@ module.exports = {
   async execute(int, client) {
     await int.deferReply({ ephemeral: true });
     const userId = int.user.id;
-    const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-    try {
-      const itemsToDelete = int.values;
-      let userItemsInCart = await localFunctions.getCart(userId, collection);
-      let newCart = userItemsInCart.filter((e) => !itemsToDelete.includes(e.name));
-      await localFunctions.setCart(userId, newCart, collection);
-      let messageComponents = new ActionRowBuilder().addComponents(
-        new ButtonBuilder()
-          .setCustomId('shopping-cart')
-          .setLabel('🛒 Check your cart')
-          .setStyle('Success'),    
-      )
-      await int.editReply({
-        content: "Your cart has been updated.",
-        components: [messageComponents],
-      });
-    } finally {
-      mongoClient.close();
-    }
+    const collection = client.db.collection("OzenCollection");
+
+    const itemsToDelete = int.values;
+    let userItemsInCart = await localFunctions.getCart(userId, collection);
+    let newCart = userItemsInCart.filter((e) => !itemsToDelete.includes(e.name));
+    await localFunctions.setCart(userId, newCart, collection);
+    let messageComponents = new ActionRowBuilder().addComponents(
+      new ButtonBuilder()
+        .setCustomId('shopping-cart')
+        .setLabel('🛒 Check your cart')
+        .setStyle('Success'),    
+    )
+    await int.editReply({
+      content: "Your cart has been updated.",
+      components: [messageComponents],
+    });
   }
 };

--- a/src/components/selectMenus/manage-collab.js
+++ b/src/components/selectMenus/manage-collab.js
@@ -1,6 +1,5 @@
 const { EmbedBuilder } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const profileMenuCache = new Map();
@@ -12,8 +11,8 @@ module.exports = {
   async execute(int, client) {
     await int.deferReply({ ephemeral: true });
     const userId = int.user.id;
-    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-    const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
+    const collection = client.db.collection("Collabs");
+    const userCollection = client.db.collection("OzenCollection");
     const guild = client.guilds.cache.get(localConstants.guildId);
     const guildMember = guild.members.cache.get(userId);
     try {
@@ -183,14 +182,11 @@ module.exports = {
 
       profileMenuCache.set(int.user.id, {
         collab: fullCollab,
-      })
+      });
 
     } catch (e) {
       console.log(e)
       await int.editReply('Something went wrong...')
-    } finally {
-      mongoClient.close();
-      mongoClientUsers.close();
     }
   },
   profileMenuCache: profileMenuCache

--- a/src/components/selectMenus/manage-perks.js
+++ b/src/components/selectMenus/manage-perks.js
@@ -1,6 +1,5 @@
 const { EmbedBuilder } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const managePerkCache = new Map();
 
@@ -10,8 +9,9 @@ module.exports = {
     },
     async execute(int, client) {
         await int.deferReply({ ephemeral: true });
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collabCollection = client.db.collection("Collabs");
         const [perkName, collabName] = int.values[0].split('-');
+
         try {
             const collab = await localFunctions.getCollab(collabName, collabCollection);
             const userPerks = collab.perks.users.filter(p => p.userId === int.user.id);
@@ -100,8 +100,6 @@ module.exports = {
         } catch (e) {
             console.log(e);
             await int.reply({ content: 'Try this interaction again... this took more than 3 seconds for some reason', ephemeral: true });
-        } finally {
-            mongoClientCollabs.close();
         }
     },
     managePerkCache: managePerkCache

--- a/src/components/selectMenus/remove-perks.js
+++ b/src/components/selectMenus/remove-perks.js
@@ -1,5 +1,4 @@
 const localFunctions = require('../../functions');
-const { connectToMongoDB } = require('../../mongo');
 const { removePerksCache } = require('../../commands/collabs/removeperks');
 
 module.exports = {
@@ -10,17 +9,14 @@ module.exports = {
         await int.deferReply({ ephemeral: true });
         const pendingUser = removePerksCache.get(int.user.id);
         if (!pendingUser) return;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        try {
-            const pendingPerks = int.values;
-            let userPerks = await localFunctions.getPerks(pendingUser.user.id, collection) || [];
+        const collection = client.db.collection("OzenCollection");
 
-            const newPerks = userPerks.filter(perk => !pendingPerks.includes(perk.name));
-            await localFunctions.setPerks(pendingUser.user.id, newPerks, collection);
-            await int.editReply(`<@${pendingUser.user.id}>'s perks have been updated.`)
-            removePerksCache.delete(int.user.id);
-        } finally {
-            mongoClient.close();
-        }
-    },
+        const pendingPerks = int.values;
+        let userPerks = await localFunctions.getPerks(pendingUser.user.id, collection) || [];
+
+        const newPerks = userPerks.filter(perk => !pendingPerks.includes(perk.name));
+        await localFunctions.setPerks(pendingUser.user.id, newPerks, collection);
+        await int.editReply(`<@${pendingUser.user.id}>'s perks have been updated.`)
+        removePerksCache.delete(int.user.id);
+    }
 };

--- a/src/components/selectMenus/select-collab.js
+++ b/src/components/selectMenus/select-collab.js
@@ -1,6 +1,5 @@
 const { EmbedBuilder, AttachmentBuilder } = require('discord.js');
 const { ActionRowBuilder, ButtonBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 const buttonCache = new Map();
@@ -12,9 +11,9 @@ module.exports = {
   async execute(int, client) {
     await int.deferReply({ ephemeral: true });
     const userId = int.user.id;
-    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-    const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-    const { collection: blacklistCollection, client: mongoClientBlacklist } = await connectToMongoDB("Blacklist");
+    const collection = client.db.collection("Collabs");
+    const userCollection = client.db.collection("OzenCollection");
+    const blacklistCollection = client.db.collection("Blacklist");
     const guild = client.guilds.cache.get(localConstants.guildId);
     const guildMember = guild.members.cache.get(userId);
     try {
@@ -406,10 +405,6 @@ module.exports = {
     } catch (e) {
       console.log(e)
       await int.editReply('Something went wrong...')
-    } finally {
-      mongoClient.close();
-      mongoClientUsers.close();
-      mongoClientBlacklist.close();
     }
   },
   buttonCache: buttonCache

--- a/src/components/selectMenus/set-tier.js
+++ b/src/components/selectMenus/set-tier.js
@@ -1,6 +1,5 @@
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
-const { connectToMongoDB } = require('../../mongo');
 const { giveTierCache } = require('../../commands/collabs/givetier');
 
 module.exports = {
@@ -14,37 +13,34 @@ module.exports = {
         const pendingMember = await guild.members.fetch(pendingUser.user.id);
 
         if (!pendingUser) return;
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        try {
-            let newPerks = [];
-            let newRoleId = '';
-            const pendingTier = int.values[0];
-            let currentTier = await localFunctions.getUserTier(pendingUser.user.id, collection);
-            if (currentTier) {
-                await pendingMember.roles.remove(currentTier.id);
-            }
+        const collection = client.db.collection("OzenCollection");
 
-            for (const tier of localConstants.premiumTiers) {
-                for (const perk of tier.perks) {
-                    newPerks.push(perk);
-                    console.log(`${perk.name} has been added.`)
-                }
-                if (pendingTier === tier.name) {
-                    newRoleId = tier.roleId;
-                    break;
-                }
-
-            }
-
-            await pendingMember.roles.add(newRoleId);
-            await pendingMember.roles.add('743505566617436301');
-            await localFunctions.setPerks(pendingUser.user.id, newPerks, collection);
-            await localFunctions.setUserTier(pendingUser.user.id, { name: pendingTier, id: newRoleId }, collection);
-
-            await int.editReply(`Tier given to <@${pendingUser.user.id}>`)
-            giveTierCache.delete(int.user.id);
-        } finally {
-            mongoClient.close();
+        let newPerks = [];
+        let newRoleId = '';
+        const pendingTier = int.values[0];
+        let currentTier = await localFunctions.getUserTier(pendingUser.user.id, collection);
+        if (currentTier) {
+            await pendingMember.roles.remove(currentTier.id);
         }
-    },
+
+        for (const tier of localConstants.premiumTiers) {
+            for (const perk of tier.perks) {
+                newPerks.push(perk);
+                console.log(`${perk.name} has been added.`)
+            }
+            if (pendingTier === tier.name) {
+                newRoleId = tier.roleId;
+                break;
+            }
+
+        }
+
+        await pendingMember.roles.add(newRoleId);
+        await pendingMember.roles.add('743505566617436301');
+        await localFunctions.setPerks(pendingUser.user.id, newPerks, collection);
+        await localFunctions.setUserTier(pendingUser.user.id, { name: pendingTier, id: newRoleId }, collection);
+
+        await int.editReply(`Tier given to <@${pendingUser.user.id}>`)
+        giveTierCache.delete(int.user.id);
+    }
 };

--- a/src/components/selectMenus/use-item.js
+++ b/src/components/selectMenus/use-item.js
@@ -1,5 +1,4 @@
 const { EmbedBuilder, PermissionsBitField, ChannelType } = require('discord.js');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
 
@@ -12,205 +11,201 @@ module.exports = {
     const userId = int.user.id;
     const guild = int.guild;
     const selectedItem = int.values[0];
-    const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-    try {
-      const userInventory = await localFunctions.getInventory(userId, collection);
+    const collection = client.db.collection("OzenCollection");
+    const userInventory = await localFunctions.getInventory(userId, collection);
 
-      if (selectedItem && userInventory.some((item) => item.name === selectedItem)) {
-      const itemIndex = userInventory.findIndex((item) => item.name === selectedItem);
-      const itemObject = userInventory.find((item) => item.name === selectedItem);
-        // Check if the selected item is the "Tokens Boost X2 72h" item
-        if (selectedItem === 'Tokens Boost X2 72h') {
-          // Check if the user already has an active boost
-          const boostEndTime = await localFunctions.getBoostEndTime(userId, collection);
+    if (selectedItem && userInventory.some((item) => item.name === selectedItem)) {
+    const itemIndex = userInventory.findIndex((item) => item.name === selectedItem);
+    const itemObject = userInventory.find((item) => item.name === selectedItem);
+      // Check if the selected item is the "Tokens Boost X2 72h" item
+      if (selectedItem === 'Tokens Boost X2 72h') {
+        // Check if the user already has an active boost
+        const boostEndTime = await localFunctions.getBoostEndTime(userId, collection);
 
-          if (!boostEndTime || Date.now() > boostEndTime) {
-            // User doesn't have an active boost or the boost has expired
-            const boostDuration = 72 * 60 * 60 * 1000; // 72 hours in milliseconds
-            const newBoostEndTime = Date.now() + boostDuration;
+        if (!boostEndTime || Date.now() > boostEndTime) {
+          // User doesn't have an active boost or the boost has expired
+          const boostDuration = 72 * 60 * 60 * 1000; // 72 hours in milliseconds
+          const newBoostEndTime = Date.now() + boostDuration;
 
-            // Set the boost end time in the database
-            await localFunctions.setBoostEndTime(userId, newBoostEndTime, collection);
+          // Set the boost end time in the database
+          await localFunctions.setBoostEndTime(userId, newBoostEndTime, collection);
 
-            await int.editReply(`<@${userId}> has activated a 2X Tokens Earned Boost for 72 hours!`);
-          } else {
-            await int.editReply({ content: "You already have an active Tokens Earned Boost.", ephemeral: true });
-          }
-        } else if (selectedItem === 'Permanent X2 Boost') {
-          const PermaBoost = await localFunctions.getPermaBoost(userId, collection);
-
-          if (!PermaBoost) {
-            await localFunctions.setPermaBoost(userId, true, collection);
-            await int.editReply(`<@${userId}> has activated a Permanent 2X Tokens Earned Boost!`);
-          } else {
-            await int.editReply({ content: "You already have an active Permanent Tokens Earned Boost.", ephemeral: true });
-          }
-        } else if (selectedItem === "Novice Active Member Role") {
-          if (int.member.roles.cache.has('1150870507445563452')) {
-            await int.editReply({ content: "You already have the role!", ephemeral: true });
-            return;
-          }
-
-          await int.member.roles.add('1150870507445563452');
-
-          if (!int.member.roles.cache.has('1150870875650928771')) {
-            await int.member.roles.add('1150870875650928771');
-            await int.member.roles.add('1150871272822161408');
-          }
-
-          await int.editReply({ content: "You have obtained the Novice Active Member Role!", ephemeral: true });
-
-
-        } else if (localConstants.channelCreationActions.includes(selectedItem)) {
-          const logChannel = int.guild.channels.cache.get('1150889016791683172');
-          const commissionsCategoryId = '1150876397875761222';
-          const commissionsCategory = guild.channels.cache.get(commissionsCategoryId);
-          guild.channels.create({
-            name: `📌・commission-${int.user.tag}`,
-            type: ChannelType.GuildText,
-            parent: commissionsCategory,
-            permissionOverwrites: [
-              {
-                id: guild.roles.everyone, // @everyone role
-                deny: [PermissionsBitField.Flags.ViewChannel], // Deny view permissions by default
-              },
-              {
-                id: userId, // User who requested the channel
-                allow: [PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.SendMessages, PermissionsBitField.Flags.ReadMessageHistory],// Allow view and send messages
-              },
-            ],
-          })
-            .then(async (channel) => {
-              await int.editReply({ content: `Commission channel created: ${channel}`, ephemeral: true });
-              const comEmbed = new EmbedBuilder()
-                .setColor('#f26e6a')
-                .setImage('https://puu.sh/JPffc/3c792e61c9.png')
-                .setThumbnail(int.user.displayAvatarURL())
-                .setTitle(`New commission for user ${int.user.tag}.`)
-                .setDescription(`**Type: ${selectedItem}**`);
-              await channel.send({
-                content: `<@${userId}> <@687004886922952755>`,
-                embeds: [comEmbed],
-                ephemeral: true,
-              });
-              const commissionLogEmbed = new EmbedBuilder()
-                .setColor('#f26e6a')
-                .setImage('https://puu.sh/JPffc/3c792e61c9.png')
-                .setAuthor({ name: "✒️ A new commission has been requested.", iconURL: int.user.displayAvatarURL() })
-                .setThumbnail('https://puu.sh/JP9Iw/a365159d0e.png')
-                .setDescription(`**Type: ${selectedItem}**\nOpened by <@${int.user.id}>\nDate: <t:${Math.floor(new Date(Date.now()) / 1000)}:F>.`)
-              logChannel.send({ content: '', embeds: [commissionLogEmbed] });
-            })
-            .catch((error) => {
-              console.error('Error creating the commission channel:', error);
-              int.editReply({ content: 'An error occurred while creating the commission channel.', ephemeral: true });
-            });
-
-        } else if (selectedItem === "Advanced Active Member Role") {
-          if (int.member.roles.cache.has('1150870529104949330')) {
-            await int.editReply({ content: "You already have the role!", ephemeral: true });
-            return;
-          }
-
-          await int.member.roles.add('1150870529104949330');
-
-          if (!int.member.roles.cache.has('1150870875650928771')) {
-            await int.member.roles.add('1150870875650928771');
-            await int.member.roles.add('1150871272822161408');
-          }
-
-          await int.editReply({ content: "You have obtained the Advanced Active Member Role!", ephemeral: true });
-
-
-        } else if (selectedItem === "Ultimate Active Member Role") {
-          if (int.member.roles.cache.has('1150870546842660904')) {
-            await int.editReply({ content: "You already have the role!", ephemeral: true });
-            return;
-          }
-
-          await int.member.roles.add('1150870546842660904');
-
-          if (!int.member.roles.cache.has('1150870875650928771')) {
-            await int.member.roles.add('1150870875650928771');
-            await int.member.roles.add('1150871272822161408');  
-          }
-
-          await int.editReply({ content: "You have obtained the **Ultimate** Active Member Role!", ephemeral: true });
-
-
-        } else if (selectedItem === "Mirage I Perk") {
-          let perk = localConstants.premiumTiers[0].perks;
-          let userPerks = await localFunctions.getPerks(userId, collection);
-          if (typeof userPerks.find(e => e.name === perk[0].name) === "undefined" || typeof userPerks.find(e => e.name === perk[1].name) === "undefined") {
-            userPerks.push(perk);
-            await localFunctions.setPerks(userId, userPerks, collection);
-          } else {
-            await int.editReply({ content: "You already have one of the perks of the Mirage I Premium Tier!", ephemeral: true });
-            return;
-          }
-          await int.editReply({ content: "You have obtained the Mirage I Perk! Check /premium", ephemeral: true });
-
-        } else if (selectedItem === "Endless Mirage Skin") {
-          let perk = localConstants.premiumTiers[4].perks[0];
-          let userPerks = await localFunctions.getPerks(userId, collection);
-          if (typeof userPerks.find(e => e.name === perk.name) === "undefined" ) {
-            userPerks.push(perk);
-            await localFunctions.setPerks(userId, userPerks, collection);
-          } else {
-            await int.editReply({ content: "You already have this perk!", ephemeral: true });
-            return;
-          }
-          await int.editReply({ content: "You have obtained the Endless Mirage Skin Perk! Check /premium", ephemeral: true });
-
-        } else if (selectedItem === "Collab Early Access") {
-          let perk = localConstants.premiumTiers[6].perks[0];
-          let userPerks = await localFunctions.getPerks(userId, collection);
-          if (typeof userPerks.find(e => e.name === perk.name) === "undefined" ) {
-            userPerks.push(perk);
-            await localFunctions.setPerks(userId, userPerks, collection);
-          } else {
-            await int.editReply({ content: "You already have this perk!", ephemeral: true });
-            return;
-          }
-          await int.editReply({ content: "You have obtained the Collab Early Access Perk! Check /premium", ephemeral: true });
-
-        } else if (selectedItem === "Global Boost") {
-          const announcementsChannel = int.guild.channels.cache.get('764561474000912434');
-          localFunctions.applyGlobalBoost(4, 24);
-          await int.editReply({ content: "Global boost applied!", ephemeral: true });
-          announcementsChannel.send(`<@&1107112464455311400> <@${int.user.id}> has activated a global 4X Token Boost for 24 hours!`);
-
-        } else if (itemObject.isReturnable) {
-          let onUseItems = await localFunctions.getOnUse(userId, collection);
-          let backgroundOnUse = onUseItems.find((item) => item.type === 'background');
-          if (backgroundOnUse) {
-            if (backgroundOnUse.name === selectedItem) {
-              await int.editReply({ content: "You're already using this cosmetic!", ephemeral: true });
-              return;
-            }
-            onUseItems = onUseItems.filter((item) => item.type !== 'background');
-            userInventory.push(backgroundOnUse);
-          }
-          onUseItems.push(itemObject);
-          await localFunctions.setOnUse(userId, onUseItems, collection);
-          await int.editReply({ content: "Cosmetic succesfully enabled!", ephemeral: true });
+          await int.editReply(`<@${userId}> has activated a 2X Tokens Earned Boost for 72 hours!`);
         } else {
-          await int.editReply({ content: "Something went wrong...", ephemeral: true });
+          await int.editReply({ content: "You already have an active Tokens Earned Boost.", ephemeral: true });
+        }
+      } else if (selectedItem === 'Permanent X2 Boost') {
+        const PermaBoost = await localFunctions.getPermaBoost(userId, collection);
+
+        if (!PermaBoost) {
+          await localFunctions.setPermaBoost(userId, true, collection);
+          await int.editReply(`<@${userId}> has activated a Permanent 2X Tokens Earned Boost!`);
+        } else {
+          await int.editReply({ content: "You already have an active Permanent Tokens Earned Boost.", ephemeral: true });
+        }
+      } else if (selectedItem === "Novice Active Member Role") {
+        if (int.member.roles.cache.has('1150870507445563452')) {
+          await int.editReply({ content: "You already have the role!", ephemeral: true });
           return;
         }
 
-        if (itemIndex !== -1) {
-          // Remove the item from the user's inventory
-          userInventory.splice(itemIndex, 1);
+        await int.member.roles.add('1150870507445563452');
 
-          // Save the updated inventory back to the database
-          await localFunctions.setInventory(userId, userInventory, collection);
+        if (!int.member.roles.cache.has('1150870875650928771')) {
+          await int.member.roles.add('1150870875650928771');
+          await int.member.roles.add('1150871272822161408');
         }
+
+        await int.editReply({ content: "You have obtained the Novice Active Member Role!", ephemeral: true });
+
+
+      } else if (localConstants.channelCreationActions.includes(selectedItem)) {
+        const logChannel = int.guild.channels.cache.get('1150889016791683172');
+        const commissionsCategoryId = '1150876397875761222';
+        const commissionsCategory = guild.channels.cache.get(commissionsCategoryId);
+        guild.channels.create({
+          name: `📌・commission-${int.user.tag}`,
+          type: ChannelType.GuildText,
+          parent: commissionsCategory,
+          permissionOverwrites: [
+            {
+              id: guild.roles.everyone, // @everyone role
+              deny: [PermissionsBitField.Flags.ViewChannel], // Deny view permissions by default
+            },
+            {
+              id: userId, // User who requested the channel
+              allow: [PermissionsBitField.Flags.ViewChannel, PermissionsBitField.Flags.SendMessages, PermissionsBitField.Flags.ReadMessageHistory],// Allow view and send messages
+            },
+          ],
+        })
+          .then(async (channel) => {
+            await int.editReply({ content: `Commission channel created: ${channel}`, ephemeral: true });
+            const comEmbed = new EmbedBuilder()
+              .setColor('#f26e6a')
+              .setImage('https://puu.sh/JPffc/3c792e61c9.png')
+              .setThumbnail(int.user.displayAvatarURL())
+              .setTitle(`New commission for user ${int.user.tag}.`)
+              .setDescription(`**Type: ${selectedItem}**`);
+            await channel.send({
+              content: `<@${userId}> <@687004886922952755>`,
+              embeds: [comEmbed],
+              ephemeral: true,
+            });
+            const commissionLogEmbed = new EmbedBuilder()
+              .setColor('#f26e6a')
+              .setImage('https://puu.sh/JPffc/3c792e61c9.png')
+              .setAuthor({ name: "✒️ A new commission has been requested.", iconURL: int.user.displayAvatarURL() })
+              .setThumbnail('https://puu.sh/JP9Iw/a365159d0e.png')
+              .setDescription(`**Type: ${selectedItem}**\nOpened by <@${int.user.id}>\nDate: <t:${Math.floor(new Date(Date.now()) / 1000)}:F>.`)
+            logChannel.send({ content: '', embeds: [commissionLogEmbed] });
+          })
+          .catch((error) => {
+            console.error('Error creating the commission channel:', error);
+            int.editReply({ content: 'An error occurred while creating the commission channel.', ephemeral: true });
+          });
+
+      } else if (selectedItem === "Advanced Active Member Role") {
+        if (int.member.roles.cache.has('1150870529104949330')) {
+          await int.editReply({ content: "You already have the role!", ephemeral: true });
+          return;
+        }
+
+        await int.member.roles.add('1150870529104949330');
+
+        if (!int.member.roles.cache.has('1150870875650928771')) {
+          await int.member.roles.add('1150870875650928771');
+          await int.member.roles.add('1150871272822161408');
+        }
+
+        await int.editReply({ content: "You have obtained the Advanced Active Member Role!", ephemeral: true });
+
+
+      } else if (selectedItem === "Ultimate Active Member Role") {
+        if (int.member.roles.cache.has('1150870546842660904')) {
+          await int.editReply({ content: "You already have the role!", ephemeral: true });
+          return;
+        }
+
+        await int.member.roles.add('1150870546842660904');
+
+        if (!int.member.roles.cache.has('1150870875650928771')) {
+          await int.member.roles.add('1150870875650928771');
+          await int.member.roles.add('1150871272822161408');  
+        }
+
+        await int.editReply({ content: "You have obtained the **Ultimate** Active Member Role!", ephemeral: true });
+
+
+      } else if (selectedItem === "Mirage I Perk") {
+        let perk = localConstants.premiumTiers[0].perks;
+        let userPerks = await localFunctions.getPerks(userId, collection);
+        if (typeof userPerks.find(e => e.name === perk[0].name) === "undefined" || typeof userPerks.find(e => e.name === perk[1].name) === "undefined") {
+          userPerks.push(perk);
+          await localFunctions.setPerks(userId, userPerks, collection);
+        } else {
+          await int.editReply({ content: "You already have one of the perks of the Mirage I Premium Tier!", ephemeral: true });
+          return;
+        }
+        await int.editReply({ content: "You have obtained the Mirage I Perk! Check /premium", ephemeral: true });
+
+      } else if (selectedItem === "Endless Mirage Skin") {
+        let perk = localConstants.premiumTiers[4].perks[0];
+        let userPerks = await localFunctions.getPerks(userId, collection);
+        if (typeof userPerks.find(e => e.name === perk.name) === "undefined" ) {
+          userPerks.push(perk);
+          await localFunctions.setPerks(userId, userPerks, collection);
+        } else {
+          await int.editReply({ content: "You already have this perk!", ephemeral: true });
+          return;
+        }
+        await int.editReply({ content: "You have obtained the Endless Mirage Skin Perk! Check /premium", ephemeral: true });
+
+      } else if (selectedItem === "Collab Early Access") {
+        let perk = localConstants.premiumTiers[6].perks[0];
+        let userPerks = await localFunctions.getPerks(userId, collection);
+        if (typeof userPerks.find(e => e.name === perk.name) === "undefined" ) {
+          userPerks.push(perk);
+          await localFunctions.setPerks(userId, userPerks, collection);
+        } else {
+          await int.editReply({ content: "You already have this perk!", ephemeral: true });
+          return;
+        }
+        await int.editReply({ content: "You have obtained the Collab Early Access Perk! Check /premium", ephemeral: true });
+
+      } else if (selectedItem === "Global Boost") {
+        const announcementsChannel = int.guild.channels.cache.get('764561474000912434');
+        localFunctions.applyGlobalBoost(4, 24);
+        await int.editReply({ content: "Global boost applied!", ephemeral: true });
+        announcementsChannel.send(`<@&1107112464455311400> <@${int.user.id}> has activated a global 4X Token Boost for 24 hours!`);
+
+      } else if (itemObject.isReturnable) {
+        let onUseItems = await localFunctions.getOnUse(userId, collection);
+        let backgroundOnUse = onUseItems.find((item) => item.type === 'background');
+        if (backgroundOnUse) {
+          if (backgroundOnUse.name === selectedItem) {
+            await int.editReply({ content: "You're already using this cosmetic!", ephemeral: true });
+            return;
+          }
+          onUseItems = onUseItems.filter((item) => item.type !== 'background');
+          userInventory.push(backgroundOnUse);
+        }
+        onUseItems.push(itemObject);
+        await localFunctions.setOnUse(userId, onUseItems, collection);
+        await int.editReply({ content: "Cosmetic succesfully enabled!", ephemeral: true });
       } else {
-        await int.editReply({ content: `You've already used ${selectedItem}!`, ephemeral: true });
+        await int.editReply({ content: "Something went wrong...", ephemeral: true });
+        return;
       }
-    } finally {
-      mongoClient.close();
+
+      if (itemIndex !== -1) {
+        // Remove the item from the user's inventory
+        userInventory.splice(itemIndex, 1);
+
+        // Save the updated inventory back to the database
+        await localFunctions.setInventory(userId, userInventory, collection);
+      }
+    } else {
+      await int.editReply({ content: `You've already used ${selectedItem}!`, ephemeral: true });
     }
   }
 };

--- a/src/components/selectMenus/use-perks.js
+++ b/src/components/selectMenus/use-perks.js
@@ -1,6 +1,5 @@
 const { TextInputStyle } = require('discord.js');
 const { ActionRowBuilder, ModalBuilder, TextInputBuilder } = require('@discordjs/builders');
-const { connectToMongoDB } = require('../../mongo');
 const localConstants = require('../../constants');
 const localFunctions = require('../../functions');
 const perkCache = new Map();
@@ -10,7 +9,7 @@ module.exports = {
         name: 'use-perks'
     },
     async execute(int, client) {
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        const collabCollection = client.db.collection("Collabs");
         const selectedPerk = int.values[0];
         const fullPerk = localConstants.premiumPerks.find(p => p.name === selectedPerk);
         try {
@@ -67,8 +66,6 @@ module.exports = {
 
         } catch {
             await int.reply({ content: 'Try this interaction again... this took more than 3 seconds for some reason', ephemeral: true });
-        } finally {
-            mongoClientCollabs.close();
         }
     },
     perkCache: perkCache

--- a/src/events/banchoClient/PM.js
+++ b/src/events/banchoClient/PM.js
@@ -1,6 +1,5 @@
 require('dotenv').config();
 const banchoUsername = process.env.OSU_USERNAME_V1;
-const { connectToMongoDB } = require('../../mongo');
 const { v2 } = require('osu-api-extended');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
@@ -10,7 +9,7 @@ module.exports = {
     async execute( message, user, discordClient) {
         if (user.ircUsername === banchoUsername) return;
         if (/^\d+$/.test(message.message) && message.message.length === 5) {
-            const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+            const collection = discordClient.db.collection("OzenCollection");
             const guild = discordClient.guilds.cache.get(localConstants.guildId);
             const logChannel = guild.channels.cache.get(localConstants.logChannelID);
             try {
@@ -56,9 +55,7 @@ module.exports = {
                 }
             } catch (e) {
                 console.log(e);
-            } finally {
-                mongoClient.close();
-            }    
+            }   
         }
     }
 }

--- a/src/events/discordClient/guildBanAdd.js
+++ b/src/events/discordClient/guildBanAdd.js
@@ -1,5 +1,4 @@
 const localConstants = require('../../constants');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
 
@@ -8,37 +7,33 @@ module.exports = {
     async execute(guild, user) {
         const userId = user.id;
         const collabLogChannel = guild.channels.cache.get(localConstants.logChannelID);
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        const { collection: blacklistCollection, client: mongoClientBlacklist } = await connectToMongoDB("Blacklist");
-        try {
-            let userCollabs = await localFunctions.getUserCollabs(userId, userCollection);
-            let user = await localFunctions.getUser(userId, userCollection);
-            if (typeof userCollabs === "undefined" || userCollabs.length === 0) return;
-            console.log(`User ${user.tag} with id ${userId} has been banned while on collabs.`);
-            await localFunctions.setBlacklist(userId, "Banned", user.osuData.osu_id, blacklistCollection);
-            for (let userCollab of userCollabs) {
-                let collab = await localFunctions.getCollab(userCollab.collabName, collection);
-                if (collab.status !== "closed" && collab.status !== "delivered" && collab.status !== "archived" && collab.status !== "completed") {
-                    userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
-                    await localFunctions.setUserCollabs(userId, userCollabs, userCollection);
-                    await localFunctions.unsetCollabParticipation(collab.name, collection, userCollab.collabPick.id);
-                    await localFunctions.removeCollabParticipant(collab.name, collection, userId);
-                    await localFunctions.unsetParticipationOnSheet(collab, userCollab.collabPick);
-                    await localFunctions.liquidateUserOsuData(userId, userCollection);
-                    const leaveEmbed = new EmbedBuilder()
-                        .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                        .setColor('#f26e6a')
-                        .setDescription(`**\`\`\`ml\n🎫 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${userCollab.collabPick.name}\nID: ${userCollab.collabPick.id}`)
-                        .setImage(userCollab.collabPick.imgURL)
-                    collabLogChannel.send({ content: `User <@${userId}> has been banned.`, embeds: [leaveEmbed] });
-                }
-                console.log(`Participation removed from ${userCollab.collabName}`);
+        const client = guild.client;
+        const userCollection = client.db.collection("OzenCollection");
+        const collection = client.db.collection("Collabs");
+        const blacklistCollection = client.db.collection("Blacklist");
+        
+        let userCollabs = await localFunctions.getUserCollabs(userId, userCollection);
+        let user = await localFunctions.getUser(userId, userCollection);
+        if (typeof userCollabs === "undefined" || userCollabs.length === 0) return;
+        console.log(`User ${user.tag} with id ${userId} has been banned while on collabs.`);
+        await localFunctions.setBlacklist(userId, "Banned", user.osuData.osu_id, blacklistCollection);
+        for (let userCollab of userCollabs) {
+            let collab = await localFunctions.getCollab(userCollab.collabName, collection);
+            if (collab.status !== "closed" && collab.status !== "delivered" && collab.status !== "archived" && collab.status !== "completed") {
+                userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
+                await localFunctions.setUserCollabs(userId, userCollabs, userCollection);
+                await localFunctions.unsetCollabParticipation(collab.name, collection, userCollab.collabPick.id);
+                await localFunctions.removeCollabParticipant(collab.name, collection, userId);
+                await localFunctions.unsetParticipationOnSheet(collab, userCollab.collabPick);
+                await localFunctions.liquidateUserOsuData(userId, userCollection);
+                const leaveEmbed = new EmbedBuilder()
+                    .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+                    .setColor('#f26e6a')
+                    .setDescription(`**\`\`\`ml\n🎫 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${userCollab.collabPick.name}\nID: ${userCollab.collabPick.id}`)
+                    .setImage(userCollab.collabPick.imgURL)
+                collabLogChannel.send({ content: `User <@${userId}> has been banned.`, embeds: [leaveEmbed] });
             }
-        } finally {
-            mongoClientUsers.close()
-            mongoClient.close()
-            mongoClientBlacklist.close();
+            console.log(`Participation removed from ${userCollab.collabName}`);
         }
     }
 }

--- a/src/events/discordClient/guildMemberRemove.js
+++ b/src/events/discordClient/guildMemberRemove.js
@@ -1,5 +1,4 @@
 const localConstants = require('../../constants');
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 const { EmbedBuilder } = require('discord.js');
 
@@ -8,32 +7,28 @@ module.exports = {
     async execute(member) {
         const userId = member.user.id;
         const collabLogChannel = member.guild.channels.cache.get(localConstants.logChannelID);
-        const { collection: userCollection, client: mongoClientUsers } = await connectToMongoDB("OzenCollection");
-        const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-        try {
-            let userCollabs = await localFunctions.getUserCollabs(userId, userCollection);
-            if (typeof userCollabs === "undefined" || userCollabs.length === 0) return;
-            console.log(`User ${member.user.tag} with id ${userId} has left the server while on collabs.`);
-            for (let userCollab of userCollabs) {
-                let collab = await localFunctions.getCollab(userCollab.collabName, collection);
-                if (collab.status !== "closed" && collab.status !== "delivered" && collab.status !== "archived" && collab.status !== "completed") {
-                    userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
-                    await localFunctions.setUserCollabs(userId, userCollabs, userCollection);
-                    await localFunctions.unsetCollabParticipation(collab.name, collection, userCollab.collabPick.id);
-                    await localFunctions.removeCollabParticipant(collab.name, collection, userId);
-                    await localFunctions.unsetParticipationOnSheet(collab, userCollab.collabPick);
-                    const leaveEmbed = new EmbedBuilder()
-                        .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
-                        .setColor('#f26e6a')
-                        .setDescription(`**\`\`\`ml\n🎫 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${userCollab.collabPick.name}\nID: ${userCollab.collabPick.id}`)
-                        .setImage(userCollab.collabPick.imgURL)
-                        collabLogChannel.send({ content: `User <@${userId}> has left the server.`, embeds: [leaveEmbed] });
-                }
-                console.log(`Participation removed from ${userCollab.collabName}`);
+        const userCollection = member.client.db.collection("OzenCollection");
+        const collection = member.client.db.collection("Collabs");
+
+        let userCollabs = await localFunctions.getUserCollabs(userId, userCollection);
+        if (typeof userCollabs === "undefined" || userCollabs.length === 0) return;
+        console.log(`User ${member.user.tag} with id ${userId} has left the server while on collabs.`);
+        for (let userCollab of userCollabs) {
+            let collab = await localFunctions.getCollab(userCollab.collabName, collection);
+            if (collab.status !== "closed" && collab.status !== "delivered" && collab.status !== "archived" && collab.status !== "completed") {
+                userCollabs = userCollabs.filter(e => e.collabName !== collab.name);
+                await localFunctions.setUserCollabs(userId, userCollabs, userCollection);
+                await localFunctions.unsetCollabParticipation(collab.name, collection, userCollab.collabPick.id);
+                await localFunctions.removeCollabParticipant(collab.name, collection, userId);
+                await localFunctions.unsetParticipationOnSheet(collab, userCollab.collabPick);
+                const leaveEmbed = new EmbedBuilder()
+                    .setFooter({ text: 'Endless Mirage | New Character Available', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
+                    .setColor('#f26e6a')
+                    .setDescription(`**\`\`\`ml\n🎫 New Character Available!\`\`\`**                                                                                                        **${collab.name}**\nName:${userCollab.collabPick.name}\nID: ${userCollab.collabPick.id}`)
+                    .setImage(userCollab.collabPick.imgURL)
+                    collabLogChannel.send({ content: `User <@${userId}> has left the server.`, embeds: [leaveEmbed] });
             }
-        } finally {
-            mongoClientUsers.close()
-            mongoClient.close()
+            console.log(`Participation removed from ${userCollab.collabName}`);
         }
     }
 }

--- a/src/events/discordClient/guildMemberUpdate.js
+++ b/src/events/discordClient/guildMemberUpdate.js
@@ -1,5 +1,4 @@
 const localFunctions = require('../../functions');
-const { connectToMongoDB } = require('../../mongo');
 
 module.exports = {
     name: 'guildMemberUpdate',
@@ -7,16 +6,13 @@ module.exports = {
         let memberUpdated = (await member.guild.members.fetch({ user: member.user.id, force: true }));
         const roles = memberUpdated.roles.cache.map(role => role.name);
         let badges = localFunctions.updateBadges(roles);
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
+        const collection = member.client.db.collection("OzenCollection");
         let userInventory = await localFunctions.getInventory(member.user.id,  collection) || [];
         let onUse = await localFunctions.getOnUse(member.user.id, collection);
-        try {
-            await localFunctions.setBadges(member.user.id, badges, collection);
-            console.log(`Badges for user ${member.user.tag} have been updated`); 
-            await localFunctions.updateNonPurchaseableCosmetics(member.user.id, collection, roles, userInventory, onUse) //Updates cosmetics
-            console.log(`Cosmetics for user ${member.user.tag} have been updated`); 
-        } finally {
-            mongoClient.close();
-        }
+
+        await localFunctions.setBadges(member.user.id, badges, collection);
+        console.log(`Badges for user ${member.user.tag} have been updated`); 
+        await localFunctions.updateNonPurchaseableCosmetics(member.user.id, collection, roles, userInventory, onUse) //Updates cosmetics
+        console.log(`Cosmetics for user ${member.user.tag} have been updated`); 
     }
 }

--- a/src/events/discordClient/interactionCreate.js
+++ b/src/events/discordClient/interactionCreate.js
@@ -1,5 +1,4 @@
 const { InteractionType } = require('discord.js')
-const { connectToMongoDB } = require('../../mongo');
 const localFunctions = require('../../functions');
 
 module.exports = {
@@ -54,182 +53,162 @@ module.exports = {
                 console.error(error);
             }
         } else if (int.isAutocomplete()) {
+            const collection = client.db.collection("Collabs");
+
             if (int.commandName === 'collabs') {
                 if (int.options.getSubcommand() === "join") {
                     const focusedValue = int.options.getFocused();
-                    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-                    try {
-                        const allCollabs = await localFunctions.getCollabs(collection);
-                        const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && c.status === "open");
-                        if (typeof openMegacollab === "undefined") {
-                            return;
-                        } else {
-                            const availablePicks = openMegacollab.pool.items.filter(i => i.status === "available");
-                            const filteredChoices = availablePicks.filter((pick) =>
-                                pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
-                            );
-                            const results = filteredChoices.map((choice) => {
-                                return {
-                                    name: `${choice.name} - ${choice.series}`,
-                                    value: choice.id
-                                }
-                            });
+                    const allCollabs = await localFunctions.getCollabs(collection);
+                    const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && c.status === "open");
 
-                            int.respond(results.slice(0, 25)).catch(() => {});
-                        }
-                    } finally {
-                        mongoClient.close();
-                    }
-                }
-                if (int.options.getSubcommand() === "manage") {
-                    const focusedValue = int.options.getFocused();
-                    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-                    try {
-                        const allCollabs = await localFunctions.getCollabs(collection);
-                        const filteredChoices = allCollabs.filter((collab) =>
-                            collab.name.toLowerCase().startsWith(focusedValue.toLowerCase())
+                    if (typeof openMegacollab === "undefined") {
+                        return;
+                    } else {
+                        const availablePicks = openMegacollab.pool.items.filter(i => i.status === "available");
+                        const filteredChoices = availablePicks.filter((pick) =>
+                            pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
                         );
                         const results = filteredChoices.map((choice) => {
                             return {
-                                name: `${choice.name}`,
-                                value: choice.name
+                                name: `${choice.name} - ${choice.series}`,
+                                value: choice.id
                             }
                         });
 
                         int.respond(results.slice(0, 25)).catch(() => {});
-                    } finally {
-                        mongoClient.close();
                     }
+                   
                 }
+                if (int.options.getSubcommand() === "manage") {
+                    const focusedValue = int.options.getFocused();
+                    const allCollabs = await localFunctions.getCollabs(collection);
+                    const filteredChoices = allCollabs.filter((collab) =>
+                        collab.name.toLowerCase().startsWith(focusedValue.toLowerCase())
+                    );
+                    const results = filteredChoices.map((choice) => {
+                        return {
+                            name: `${choice.name}`,
+                            value: choice.name
+                        }
+                    });
+
+                    int.respond(results.slice(0, 25)).catch(() => {});
+                   
+                }
+
                 if (int.options.getSubcommand() === "swap") {
                     const focusedValue = int.options.getFocused();
-                    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-                    try {
-                        const allCollabs = await localFunctions.getCollabs(collection);
-                        const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && c.status === "open");
-                        if (typeof openMegacollab === "undefined") {
-                            return;
-                        } else {
-                            const availablePicks = openMegacollab.pool.items.filter(i => i.status === "available");
-                            const filteredChoices = availablePicks.filter((pick) =>
-                                pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
-                            );
-                            const results = filteredChoices.map((choice) => {
-                                return {
-                                    name: `${choice.name} - ${choice.series}`,
-                                    value: choice.id
-                                }
-                            });
+                    const allCollabs = await localFunctions.getCollabs(collection);
+                    const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && c.status === "open");
+                    
+                    if (typeof openMegacollab === "undefined") {
+                        return;
+                    } else {
+                        const availablePicks = openMegacollab.pool.items.filter(i => i.status === "available");
+                        const filteredChoices = availablePicks.filter((pick) =>
+                            pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
+                        );
+                        const results = filteredChoices.map((choice) => {
+                            return {
+                                name: `${choice.name} - ${choice.series}`,
+                                value: choice.id
+                            }
+                        });
 
-                            int.respond(results.slice(0, 25)).catch(() => {});
-                        }
-                    } finally {
-                        mongoClient.close();
+                        int.respond(results.slice(0, 25)).catch(() => {});
                     }
                 }
+
                 if (int.options.getSubcommand() === "trade") {
                     const focusedValue = int.options.getFocused();
-                    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-                    try {
-                        const allCollabs = await localFunctions.getCollabs(collection);
-                        const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && c.status === "open");
-                        if (typeof openMegacollab === "undefined") {
-                            return;
-                        } else {
-                            const availablePicks = openMegacollab.pool.items.filter(i => i.status === "picked");
-                            const filteredChoices = availablePicks.filter((pick) =>
-                                pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
-                            );
-                            const results = filteredChoices.map((choice) => {
-                                return {
-                                    name: `${choice.name} - ${choice.series}`,
-                                    value: choice.id
-                                }
-                            });
+                    const allCollabs = await localFunctions.getCollabs(collection);
+                    const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && c.status === "open");
+                    
+                    if (typeof openMegacollab === "undefined") {
+                        return;
+                    } else {
+                        const availablePicks = openMegacollab.pool.items.filter(i => i.status === "picked");
+                        const filteredChoices = availablePicks.filter((pick) =>
+                            pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
+                        );
+                        const results = filteredChoices.map((choice) => {
+                            return {
+                                name: `${choice.name} - ${choice.series}`,
+                                value: choice.id
+                            }
+                        });
 
-                            int.respond(results.slice(0, 25)).catch(() => {});
-                        }
-                    } finally {
-                        mongoClient.close();
+                        int.respond(results.slice(0, 25)).catch(() => {});
                     }
                 }
+
                 if (int.options.getSubcommand() === "pick-check") {
                     const focusedValue = int.options.getFocused();
-                    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-                    try {
-                        const allCollabs = await localFunctions.getCollabs(collection);
-                        const openMegacollab = allCollabs.find(c => c.restriction === "megacollab");
-                        if (typeof openMegacollab === "undefined") {
-                            return;
-                        } else {
-                            const picks = openMegacollab.pool.items;
-                            const filteredChoices = picks.filter((pick) =>
-                                pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
-                            );
-                            const results = filteredChoices.map((choice) => {
-                                return {
-                                    name: `${choice.name} - ${choice.series}`,
-                                    value: choice.id
-                                }
-                            });
+                    const allCollabs = await localFunctions.getCollabs(collection);
+                    const openMegacollab = allCollabs.find(c => c.restriction === "megacollab");
 
-                            int.respond(results.slice(0, 25)).catch(() => {});
-                        }
-                    } finally {
-                        mongoClient.close();
+                    if (typeof openMegacollab === "undefined") {
+                        return;
+                    } else {
+                        const picks = openMegacollab.pool.items;
+                        const filteredChoices = picks.filter((pick) =>
+                            pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
+                        );
+                        const results = filteredChoices.map((choice) => {
+                            return {
+                                name: `${choice.name} - ${choice.series}`,
+                                value: choice.id
+                            }
+                        });
+
+                        int.respond(results.slice(0, 25)).catch(() => {});
                     }
                 }
+
                 if (int.options.getSubcommand() === "user-check") {
                     const focusedValue = int.options.getFocused();
-                    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-                    try {
-                        const allCollabs = await localFunctions.getCollabs(collection);
-                        const openMegacollab = allCollabs.find(c => c.restriction === "megacollab");
-                        if (typeof openMegacollab === "undefined") {
-                            return;
-                        } else {
-                            if (typeof openMegacollab.participants === "undefined") return;
-                            const participants = openMegacollab.participants;
-                            const filteredChoices = participants.filter((user) =>
-                                user.discordTag.toLowerCase().startsWith(focusedValue.toLowerCase())
-                            );
-                            const results = filteredChoices.map((choice) => {
-                                return {
-                                    name: `${choice.discordTag} - ${choice.name} - ${choice.series}`,
-                                    value: choice.discordId
-                                }
-                            });
+                    const allCollabs = await localFunctions.getCollabs(collection);
+                    const openMegacollab = allCollabs.find(c => c.restriction === "megacollab");
+                    
+                    if (typeof openMegacollab === "undefined") {
+                        return;
+                    } else {
+                        if (typeof openMegacollab.participants === "undefined") return;
+                        const participants = openMegacollab.participants;
+                        const filteredChoices = participants.filter((user) =>
+                            user.discordTag.toLowerCase().startsWith(focusedValue.toLowerCase())
+                        );
+                        const results = filteredChoices.map((choice) => {
+                            return {
+                                name: `${choice.discordTag} - ${choice.name} - ${choice.series}`,
+                                value: choice.discordId
+                            }
+                        });
 
-                            int.respond(results.slice(0, 25)).catch(() => {});
-                        }
-                    } finally {
-                        mongoClient.close();
+                        int.respond(results.slice(0, 25)).catch(() => {});
                     }
                 }
+
                 if (int.options.getSubcommand() === "snipe") {
                     const focusedValue = int.options.getFocused();
-                    const { collection, client: mongoClient } = await connectToMongoDB("Collabs");
-                    try {
-                        const allCollabs = await localFunctions.getCollabs(collection);
-                        const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && (c.status !== "delivered" || c.status !== "archived" || c.status !== "completed"));
-                        if (typeof openMegacollab === "undefined") {
-                            return;
-                        } else {
-                            const pickedPicks = openMegacollab.participants;
-                            const filteredChoices = pickedPicks.filter((pick) =>
-                                pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
-                            );
-                            const results = filteredChoices.map((choice) => {
-                                return {
-                                    name: `${choice.name} - ${choice.series} - Picked by: ${choice.username}`,
-                                    value: choice.id
-                                }
-                            });
+                    const allCollabs = await localFunctions.getCollabs(collection);
+                    const openMegacollab = allCollabs.find(c => c.restriction === "megacollab" && (c.status !== "delivered" || c.status !== "archived" || c.status !== "completed"));
+                    
+                    if (typeof openMegacollab === "undefined") {
+                        return;
+                    } else {
+                        const pickedPicks = openMegacollab.participants;
+                        const filteredChoices = pickedPicks.filter((pick) =>
+                            pick.name.toLowerCase().startsWith(focusedValue.toLowerCase())
+                        );
+                        const results = filteredChoices.map((choice) => {
+                            return {
+                                name: `${choice.name} - ${choice.series} - Picked by: ${choice.username}`,
+                                value: choice.id
+                            }
+                        });
 
-                            int.respond(results.slice(0, 25)).catch(() => {});
-                        }
-                    } finally {
-                        mongoClient.close();
+                        int.respond(results.slice(0, 25)).catch(() => {});
                     }
                 }
             }

--- a/src/events/discordClient/messageCreate.js
+++ b/src/events/discordClient/messageCreate.js
@@ -1,4 +1,3 @@
-const { connectToMongoDB } = require('../../mongo');
 const { connectToSpreadsheet } = require('../../googleSheets');
 const localFunctions = require('../../functions');
 const localConstants = require('../../constants');
@@ -11,10 +10,11 @@ const userCombos = new Map();
 
 module.exports = {
     name: 'messageCreate',
-    async execute(message) {
+    async execute(message, client) {
         if (message.author.bot) return;
         if (message.channel.type === 'dm') return;
         if (message.guildId !== '630281137998004224') return;
+
         const userId = message.author.id;
         const currentTime = Date.now();
 
@@ -40,10 +40,11 @@ module.exports = {
         const startOfDay = new Date(currentTime);
         startOfDay.setHours(0, 0, 0, 0);
 
-        // Establish a connection to MongoDB
-        const { collection, client: mongoClient } = await connectToMongoDB("OzenCollection");
-        const { collection: collectionSpecial, client: mongoClientSpecial } = await connectToMongoDB("Special");
-        const { collection: collabCollection, client: mongoClientCollabs } = await connectToMongoDB("Collabs");
+        // Grab the MongoDB collections.
+        const collection = client.db.collection("OzenCollection");
+        const collectionSpecial = client.db.collection("Special");
+        const collabCollection = client.db.collection("Collabs");
+
         const globalBoost = await localFunctions.getGlobalBoost(collectionSpecial);
         const globalBoostEndTime = globalBoost.boostEndTime;
         const globalBoostValue = globalBoost.multiplier;
@@ -292,10 +293,6 @@ module.exports = {
             userCooldowns.set(userId, currentTime);
         } catch (e) {
             console.log(e);
-        } finally {
-            mongoClient.close();
-            mongoClientSpecial.close();
-            mongoClientCollabs.close();
         }
     }
 }

--- a/src/events/discordClient/ready.js
+++ b/src/events/discordClient/ready.js
@@ -7,12 +7,13 @@ module.exports = {
     async execute(client) {
         localFunctions.scheduleDailyDecay(client);
         console.log('Ready.');
+        
         await client.user.setPresence({
             activities: [{
                 name: "you <3",
                 type: ActivityType.Watching
             }],
             status: "online"
-        })
+        });
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 require('dotenv').config();
-const { auth } = require('osu-api-extended')
+
+const { auth } = require('osu-api-extended');
+const { MongoClient } = require('mongodb');
 const { Client, Collection, GatewayIntentBits, Partials } = require('discord.js');
 const fs = require('fs');
 const path = require('path');
@@ -47,7 +49,23 @@ client.handleEvents();
 client.handleCommands();
 client.handleComponents();
 
+async function main() {
+  // Connect to MongoDB.
+  const mongoClient = new MongoClient(process.env.MONGO);
+  await mongoClient.connect();
+  client.db = mongoClient.db("Ozen");
+  console.log('Connected to MongoDB.');
 
-banchoClient.connect().then(() => {console.log('Connected to bancho.')});
-auth.login(clientIDv2, clientSv2, ['public']).then(() => {console.log('Connected to osu api.')});
-client.login(discordToken);
+  // Connect to Bancho.
+  await banchoClient.connect();
+  console.log('Connected to bancho.');
+
+  // Connect to osu! API.
+  await auth.login(clientIDv2, clientSv2, ['public']);
+  console.log('Connected to osu api.');
+
+  // Connect to Discord.
+  await client.login(discordToken);
+}
+
+main();


### PR DESCRIPTION
You were creating dozens of connections to the database all around, this is bad, it slows down the bot, creates unnecessary load on the database, and increases memory usage.

an instance of a `MongoClient` represents a "connection pool" meaning it will automatically manage multiple connections to the database as needed, this was mentioned in the official documentation:

![image](https://github.com/XegSo/Miira/assets/31079629/60ec33b9-8580-4d2d-9ed3-1f2ac1f23e9c)

This PR creates one MongoDB Client and attaches it to the discord `client` object so it's available everywhere, anytime database access is required just access the database via the client by doing `client.db` e.g `client.db.collection("Collabs")`

I have tried my best to not touch anything else so the logic should not change and hopefully nothing breaks provided I didn't make any typos.

There are still a few more connections creating code remaining in `functions.js` but that will need a bit more changes around the code, I wanted to first get this functionality working before I risk any breakage but the end goal is to eventually delete the `mongo.js` file, no other part of the code should be making any new connections to the database.