### PR TITLE
fix: guildBanAdd event arguments

### DIFF
--- a/src/events/discordClient/guildBanAdd.js
+++ b/src/events/discordClient/guildBanAdd.js
@@ -4,7 +4,7 @@ const { EmbedBuilder } = require('discord.js');
 
 module.exports = {
     name: 'guildBanAdd',
-    async execute(guild, user) {
+    async execute({ guild, user }) {
         const userId = user.id;
         const collabLogChannel = guild.channels.cache.get(localConstants.logChannelID);
         const client = guild.client;


### PR DESCRIPTION
The event actually gives a `GuildBan` object that we need to grab the `user` and `guild` fields from inside that object. Getting a user/guild directly was an old convention back in discord.js v12 days.

See:
* https://discord.js.org/docs/packages/discord.js/14.14.1/GuildBan:Class
* https://discord.js.org/docs/packages/discord.js/14.14.1/Client:Class#guildBanAdd