### PR TITLE
feat: show the mod that accepted/rejected an image request

### DIFF
--- a/src/components/buttons/swap-image-approve.js
+++ b/src/components/buttons/swap-image-approve.js
@@ -21,6 +21,7 @@ module.exports = {
         await localFunctions.editPickImage(request.pickId, request.user, request.collab, collabCollection, userCollection, newImgURL);
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         let imageSwapEmbed = new EmbedBuilder()
+            .setAuthor({ name: int.user.tag, iconURL: int.user.displayAvatarURL({ size: 64 }) })
             .setFooter({ text: 'Endless Mirage | Accepted Request', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
             .setColor('#f26e6a')
             .setTimestamp()

--- a/src/components/modals/swap-image-deny.js
+++ b/src/components/modals/swap-image-deny.js
@@ -18,6 +18,7 @@ module.exports = {
         const reason = int.fields.getTextInputValue('reason');
         const logChannel = guild.channels.cache.get(localConstants.logChannelID);
         let imageSwapEmbed = new EmbedBuilder()
+            .setAuthor({ name: int.user.tag, iconURL: int.user.displayAvatarURL({ size: 64 }) })
             .setFooter({ text: 'Endless Mirage | Rejected Request', iconURL: 'https://puu.sh/JP9Iw/a365159d0e.png' })
             .setColor('#f26e6a')
             .setTimestamp()


### PR DESCRIPTION
I just thought for our records it's better to know the staff that acted on a specific request, so this now adds an author field on the request embed displaying the user that acted on the request.